### PR TITLE
Remove redundancy in server MultiplayerController.

### DIFF
--- a/integration/src/integration/java/com/forerunnergames/peril/integration/core/func/init/InitialGamePhaseController.java
+++ b/integration/src/integration/java/com/forerunnergames/peril/integration/core/func/init/InitialGamePhaseController.java
@@ -230,7 +230,7 @@ public final class InitialGamePhaseController implements TestPhaseController
 
     processor.start (EndInitialReinforcementPhaseEvent.class, monitor);
 
-    monitor.awaitCompletion (10000000);
+    monitor.awaitCompletion ();
   }
 
   private void sendForAllClientsJoinGameRequest ()

--- a/server/src/main/java/com/forerunnergames/peril/server/dispatchers/ClientRequestEventDispatchListener.java
+++ b/server/src/main/java/com/forerunnergames/peril/server/dispatchers/ClientRequestEventDispatchListener.java
@@ -1,9 +1,8 @@
 package com.forerunnergames.peril.server.dispatchers;
 
-import com.forerunnergames.peril.common.net.events.client.interfaces.PlayerInformRequestEvent;
+import com.forerunnergames.peril.common.net.events.client.interfaces.PlayerAnswerEvent;
 import com.forerunnergames.peril.common.net.events.client.interfaces.PlayerJoinGameRequestEvent;
 import com.forerunnergames.peril.common.net.events.client.interfaces.PlayerRequestEvent;
-import com.forerunnergames.peril.common.net.events.client.interfaces.PlayerResponseRequestEvent;
 import com.forerunnergames.peril.common.net.events.client.request.AiJoinGameServerRequestEvent;
 import com.forerunnergames.peril.common.net.events.client.request.ChatMessageRequestEvent;
 import com.forerunnergames.peril.common.net.events.client.request.HumanJoinGameServerRequestEvent;
@@ -27,7 +26,5 @@ public interface ClientRequestEventDispatchListener
 
   void handleEvent (final PlayerRequestEvent event, final RemoteClient client);
 
-  void handleEvent (final PlayerResponseRequestEvent <?> event, final RemoteClient client);
-
-  void handleEvent (final PlayerInformRequestEvent <?> event, final RemoteClient client);
+  void handleEvent (final PlayerAnswerEvent <?> event, final RemoteClient client);
 }


### PR DESCRIPTION
The new PlayerInputEvent/PlayerAnswerEvent event structure allows
for server::MultiplayerController to handle all player answer events
polymorphically instead of repeating code for response-requests and
inform events.

Additional changes:
- Remove previous debugging modification to InitialGamePhaseController
  in integration module.