### PR TITLE
Fix event registry creating separate event bus.

### DIFF
--- a/common/src/main/java/com/forerunnergames/peril/common/net/dispatchers/AbstractNetworkEventDispatcher.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/dispatchers/AbstractNetworkEventDispatcher.java
@@ -36,9 +36,9 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Uses {@link MBassador} to resolve the runtime types of various events. It is the responsibility of implementors to
- * provide {@link Handler} methods for the interested events. Remembers the original remote client sender called via
- * {@link #dispatch(Event, RemoteClient)}, providing a mechanism to resolve the sender, for implementors to use, via
- * {@link #senderOfDispatchedEvent(Event)}.
+ * provide {@link Handler} methods for the interested events. This class remembers the original remote client sender
+ * called via {@link #dispatch(Event, RemoteClient)}, providing a mechanism to resolve the sender, for implementors to
+ * use, via {@link #senderOfDispatchedEvent(Event)}.
  */
 public abstract class AbstractNetworkEventDispatcher implements NetworkEventDispatcher
 {

--- a/core/src/main/java/com/forerunnergames/peril/core/events/DefaultEventRegistry.java
+++ b/core/src/main/java/com/forerunnergames/peril/core/events/DefaultEventRegistry.java
@@ -41,11 +41,13 @@ public class DefaultEventRegistry implements EventRegistry
   private final Multimap <PlayerPacket, Event> playersToEvents = HashMultimap.create ();
   private final Set <PlayerInputEvent> unmappedInputEvents = Sets.newHashSet ();
   private final BiMap <PlayerAnswerEvent <?>, PlayerInputEvent> answerToInputEvents;
-  private final MBassador <Event> eventBus = new MBassador <> ();
+  private final MBassador <Event> eventBus;
 
   public DefaultEventRegistry (final MBassador <Event> eventBus)
   {
     Arguments.checkIsNotNull (eventBus, "eventBus");
+
+    this.eventBus = eventBus;
 
     answerToInputEvents = HashBiMap.create ();
 


### PR DESCRIPTION
For some reason, DefaultEventRegistry was creating a new event bus via
the MBassador default constructor (why, I have no idea).

This would have caused some nasty bugs later, including with PERIL-373,
since this broke republication in DefaultEventRegistry (it would have been
publishing to an unused event bus). The only reason it worked at all was
because DefaultEventRegistry was still registering itself to the correct
event bus passed through the ctor parameter.

This also fixes the issue reported in PERIL-885, relevance of PERIL-888
notwithstanding, since it eliminates the spurious log messages printed by
the unused event bus.

Additional changes:
- Minor OCD correction to javadoc in AbstractNetworkEventDispatcher.

PERIL-885 #Done #time 20m