### PR TITLE
Fix last occupation not triggering win game events.

### DIFF
--- a/core/src/main/java/com/forerunnergames/peril/core/model/game/phase/AbstractGamePhaseHandler.java
+++ b/core/src/main/java/com/forerunnergames/peril/core/model/game/phase/AbstractGamePhaseHandler.java
@@ -289,7 +289,7 @@ public abstract class AbstractGamePhaseHandler implements GamePhaseHandler
   /**
    * Checks whether or not a player has won or lost the game in the current game state
    */
-  protected void checkPlayerGameStatus (final Id playerId)
+  protected GameStatus checkPlayerGameStatus (final Id playerId)
   {
     final int playerCountryCount = countryOwnerModel.countCountriesOwnedBy (playerId);
     GameStatus status = GameStatus.CONTINUE_PLAYING;
@@ -301,9 +301,11 @@ public abstract class AbstractGamePhaseHandler implements GamePhaseHandler
     // sure we don't make the player win twice if multiple win conditions are satisfied simultaneously.
     // If the player already won from all other players losing and being removed, there is no need to
     // check if the winning country count was satisfied.
-    if (status == GameStatus.GAME_OVER) return;
+    if (status == GameStatus.GAME_OVER) return status;
 
-    if (playerCountryCount >= rules.getWinningCountryCount ()) playerWinsGame (playerId);
+    if (playerCountryCount >= rules.getWinningCountryCount ()) status = playerWinsGame (playerId);
+
+    return status;
   }
 
   protected GameStatus playerWinsGame (final Id playerId)

--- a/core/src/main/java/com/forerunnergames/peril/core/model/game/phase/turn/DefaultAttackPhaseHandler.java
+++ b/core/src/main/java/com/forerunnergames/peril/core/model/game/phase/turn/DefaultAttackPhaseHandler.java
@@ -49,6 +49,7 @@ import com.forerunnergames.peril.core.model.battle.FinalBattleActor;
 import com.forerunnergames.peril.core.model.battle.PendingBattleActor;
 import com.forerunnergames.peril.core.model.game.CacheKey;
 import com.forerunnergames.peril.core.model.game.GameModelConfiguration;
+import com.forerunnergames.peril.core.model.game.GameStatus;
 import com.forerunnergames.peril.core.model.game.phase.AbstractGamePhaseHandler;
 import com.forerunnergames.peril.core.model.state.annotations.StateEntryAction;
 import com.forerunnergames.peril.core.model.state.annotations.StateExitAction;
@@ -559,7 +560,9 @@ public final class DefaultAttackPhaseHandler extends AbstractGamePhaseHandler im
     clearCacheValues (CacheKey.OCCUPY_SOURCE_COUNTRY, CacheKey.OCCUPY_TARGET_COUNTRY, CacheKey.OCCUPY_PREV_OWNER,
                       CacheKey.OCCUPY_NEW_OWNER, CacheKey.OCCUPY_MIN_ARMY_COUNT, CacheKey.OCCUPY_MAX_ARMY_COUNT);
 
-    return true;
+    // Will NOT trigger normal turn transition if player has won the game. Instead, PlayerWinGameEvent and EndGameEvent
+    // will be fired, triggering a transition into the end state.
+    return checkPlayerGameStatus (getCurrentPlayerId ()) == GameStatus.CONTINUE_PLAYING;
   }
 
   private PendingBattleActorPacket createPendingAttackerPacket (final AttackVector attackVector)

--- a/core/src/test/java/com/forerunnergames/peril/core/model/game/phase/AbstractGamePhaseHandlerTest.java
+++ b/core/src/test/java/com/forerunnergames/peril/core/model/game/phase/AbstractGamePhaseHandlerTest.java
@@ -27,10 +27,12 @@ import com.forerunnergames.peril.core.model.card.Card;
 import com.forerunnergames.peril.core.model.card.CardModel;
 import com.forerunnergames.peril.core.model.card.CardModelTest;
 import com.forerunnergames.peril.core.model.card.DefaultCardModel;
+import com.forerunnergames.peril.core.model.game.CacheKey;
 import com.forerunnergames.peril.core.model.game.DefaultGamePhaseEventFactory;
 import com.forerunnergames.peril.core.model.game.GameModel;
 import com.forerunnergames.peril.core.model.game.GameModelConfiguration;
 import com.forerunnergames.peril.core.model.game.GamePhaseEventFactory;
+import com.forerunnergames.peril.core.model.game.PlayerTurnDataCache;
 import com.forerunnergames.peril.core.model.people.player.DefaultPlayerModel;
 import com.forerunnergames.peril.core.model.people.player.PlayerModel;
 import com.forerunnergames.peril.core.model.playmap.DefaultPlayMapModelFactory;
@@ -87,6 +89,7 @@ public abstract class AbstractGamePhaseHandlerTest
   protected int maxPlayers;
   protected GameModelConfiguration gameModelConfig;
   protected GameModel gameModel;
+  protected PlayerTurnDataCache <CacheKey> turnDataCache;
   protected PlayerModel playerModel;
   protected PlayerTurnModel playerTurnModel;
   protected PlayMapModel playMapModel;
@@ -318,9 +321,11 @@ public abstract class AbstractGamePhaseHandlerTest
     initialArmies = gameRules.getInitialArmies ();
     playerLimit = playerModel.getPlayerLimit ();
     maxPlayers = gameRules.getMaxTotalPlayers ();
+    turnDataCache = new PlayerTurnDataCache <> ();
     gameModelConfig = GameModelConfiguration.builder (gameRules).asyncExecutor (mockAsyncExecution).eventBus (eventBus)
             .eventRegistry (mockEventRegistry).playMapModel (playMapModel).battleModel (battleModel)
-            .playerModel (playerModel).playerTurnModel (playerTurnModel).cardModel (cardModel).build ();
+            .playerModel (playerModel).turnDataCache (turnDataCache).playerTurnModel (playerTurnModel)
+            .cardModel (cardModel).build ();
     gameModel = GameModel.create (gameModelConfig);
   }
 

--- a/core/src/test/java/com/forerunnergames/peril/core/model/game/phase/turn/BattlePhaseHandlerTest.java
+++ b/core/src/test/java/com/forerunnergames/peril/core/model/game/phase/turn/BattlePhaseHandlerTest.java
@@ -1,0 +1,95 @@
+package com.forerunnergames.peril.core.model.game.phase.turn;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.forerunnergames.peril.common.net.events.client.request.response.PlayerOccupyCountryResponseRequestEvent;
+import com.forerunnergames.peril.common.net.events.server.interfaces.CountryArmiesChangedEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndGameEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.PlayerWinGameEvent;
+import com.forerunnergames.peril.common.net.events.server.success.PlayerOccupyCountryResponseSuccessEvent;
+import com.forerunnergames.peril.core.model.game.CacheKey;
+import com.forerunnergames.peril.core.model.game.phase.AbstractGamePhaseHandlerTest;
+import com.forerunnergames.peril.core.model.people.player.PlayerTurnOrder;
+import com.forerunnergames.peril.core.model.playmap.PlayMapStateBuilder;
+import com.forerunnergames.tools.common.id.Id;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+
+import org.junit.Test;
+
+public class BattlePhaseHandlerTest extends AbstractGamePhaseHandlerTest
+{
+  private AttackPhaseHandler attackPhase;
+
+  @Override
+  protected void setupTest ()
+  {
+    initializeGameModelWith (createPlayMapModelWithTestTerritoryGraphs (defaultTestCountries));
+    addMaxPlayers ();
+    attackPhase = new DefaultAttackPhaseHandler (gameModelConfig);
+    phaseHandlerBase = attackPhase;
+  }
+
+  // TODO Add more attack phase unit tests
+
+  @Test
+  public void testLastOccupiedCountryTriggersWinGame ()
+  {
+    addMaxPlayers ();
+    final Id firstPlayer = playerModel.playerWith (PlayerTurnOrder.FIRST);
+    final Id secondPlayer = playerModel.playerWith (PlayerTurnOrder.SECOND);
+    final int sourceCountryArmyCount = 10;
+    final int deltaArmyCount = 4;
+    final int attackerDieCount = 3;
+    final PlayMapStateBuilder stateBuilder = new PlayMapStateBuilder (playMapModel);
+    final Id sourceCountryId = Iterables.getFirst (countryGraphModel.getCountryIds (), null);
+    final Id targetCountryId = Iterables.getFirst (countryGraphModel.getAdjacentNodes (sourceCountryId), null);
+    assertNotNull (sourceCountryId);
+    assertNotNull (targetCountryId);
+    // set owner for all countries
+    stateBuilder.forCountries (countryGraphModel.getCountryIds ()).setOwner (firstPlayer);
+    // add source army count for all countries except the one we are occupying
+    stateBuilder.forCountries (Sets.difference (countryGraphModel.getCountryIds (), ImmutableSet.of (targetCountryId)))
+            .addArmies (sourceCountryArmyCount);
+    turnDataCache.put (CacheKey.OCCUPY_SOURCE_COUNTRY, countryGraphModel.countryPacketWith (sourceCountryId));
+    turnDataCache.put (CacheKey.OCCUPY_TARGET_COUNTRY, countryGraphModel.countryPacketWith (targetCountryId));
+    turnDataCache.put (CacheKey.OCCUPY_PREV_OWNER, playerModel.playerPacketWith (secondPlayer));
+    turnDataCache.put (CacheKey.OCCUPY_MIN_ARMY_COUNT, gameRules.getMinOccupyArmyCount (attackerDieCount));
+    final PlayerOccupyCountryResponseRequestEvent response = new PlayerOccupyCountryResponseRequestEvent (
+            deltaArmyCount);
+    assertFalse (attackPhase.verifyPlayerOccupyCountryResponseRequest (response));
+    assertTrue (eventHandler.wasFiredExactlyOnce (PlayerOccupyCountryResponseSuccessEvent.class));
+    assertTrue (eventHandler.wasFiredExactlyNTimes (CountryArmiesChangedEvent.class, 2));
+
+    // check country change events
+    final Predicate <CountryArmiesChangedEvent> sourceCountryPredicate = new Predicate <CountryArmiesChangedEvent> ()
+    {
+      @Override
+      public boolean apply (final CountryArmiesChangedEvent input)
+      {
+        return input.getCountry ().is (countryGraphModel.countryPacketWith (sourceCountryId))
+                && input.getCountryArmyCount () == sourceCountryArmyCount - deltaArmyCount;
+      }
+    };
+    final Predicate <CountryArmiesChangedEvent> targetCountryPredicate = new Predicate <CountryArmiesChangedEvent> ()
+    {
+      @Override
+      public boolean apply (final CountryArmiesChangedEvent input)
+      {
+        return input.getCountry ().is (countryGraphModel.countryPacketWith (targetCountryId))
+                && input.getCountryArmyCount () == deltaArmyCount;
+      }
+    };
+    assertNotNull (eventHandler.lastEventWhere (CountryArmiesChangedEvent.class, sourceCountryPredicate));
+    assertNotNull (eventHandler.lastEventWhere (CountryArmiesChangedEvent.class, targetCountryPredicate));
+
+    // ensure win game events were fired
+    assertTrue (eventHandler.wasFiredExactlyOnce (PlayerWinGameEvent.class));
+    assertTrue (eventHandler.wasFiredExactlyOnce (EndGameEvent.class));
+  }
+}


### PR DESCRIPTION
Current player occupying last country for win conditions now
triggers a PlayerWinGameEvent to be fired AFTER the occupation success
event. It also blocks the normal subsequent turn phase state transition
and instead triggers a transition into the EndGame state.

Additional changes:
- Add battle phase unit test class (kind of bad that it didn't exist before)
  and add unit test for these changes.
- Add TODO comment for more battle phase unit tests :/

PERIL-795 #time 45m #Done