### PR TITLE
Finish client-side reconnection, II.

### DIFF
--- a/ai/src/main/java/com/forerunnergames/peril/ai/processors/ChatProcessor.java
+++ b/ai/src/main/java/com/forerunnergames/peril/ai/processors/ChatProcessor.java
@@ -40,7 +40,7 @@ import com.forerunnergames.peril.common.net.events.server.notify.broadcast.Begin
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginFortifyPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginGameEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginInitialReinforcementPhaseEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginPlayerCountryAssignmentEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginInitialCountryAssignmentPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginPlayerTurnEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginReinforcementPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginRoundEvent;
@@ -157,7 +157,7 @@ public final class ChatProcessor extends AbstractAiProcessor
   }
 
   @Handler
-  void onEvent (final BeginPlayerCountryAssignmentEvent event)
+  void onEvent (final BeginInitialCountryAssignmentPhaseEvent event)
   {
     Arguments.checkIsNotNull (event, "event");
 

--- a/ai/src/main/java/com/forerunnergames/peril/ai/processors/GameLogicProcessor.java
+++ b/ai/src/main/java/com/forerunnergames/peril/ai/processors/GameLogicProcessor.java
@@ -52,7 +52,7 @@ import com.forerunnergames.peril.common.net.events.server.notify.broadcast.Begin
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginFortifyPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginGameEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginInitialReinforcementPhaseEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginPlayerCountryAssignmentEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginInitialCountryAssignmentPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginPlayerTurnEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginReinforcementPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginRoundEvent;
@@ -153,7 +153,7 @@ public final class GameLogicProcessor extends AbstractAiProcessor
   }
 
   @Handler
-  void onEvent (final BeginPlayerCountryAssignmentEvent event)
+  void onEvent (final BeginInitialCountryAssignmentPhaseEvent event)
   {
     Arguments.checkIsNotNull (event, "event");
 

--- a/client/src/main/java/com/forerunnergames/peril/client/events/DisconnectFromServerDebugEvent.java
+++ b/client/src/main/java/com/forerunnergames/peril/client/events/DisconnectFromServerDebugEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Forerunner Games, LLC.
+ * Copyright © 2016 Forerunner Games, LLC.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,18 +15,11 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.forerunnergames.peril.common.game;
+package com.forerunnergames.peril.client.events;
 
-public enum GamePhase
+import com.forerunnergames.tools.net.events.local.LocalEvent;
+
+// TODO Production: Remove.
+public final class DisconnectFromServerDebugEvent implements LocalEvent
 {
-  INITIAL,
-  INITIAL_COUNTRY_ASSIGNMENT,
-  INITIAL_REINFORCEMENT,
-  TURN,
-  REINFORCEMENT,
-  ATTACK,
-  FORTIFY,
-  END,
-  SUSPENDED,
-  UNKNOWN
 }

--- a/client/src/main/java/com/forerunnergames/peril/client/net/MultiplayerController.java
+++ b/client/src/main/java/com/forerunnergames/peril/client/net/MultiplayerController.java
@@ -28,7 +28,7 @@ import com.forerunnergames.peril.client.events.ConnectToServerSuccessEvent;
 import com.forerunnergames.peril.client.events.CreateGameServerDeniedEvent;
 import com.forerunnergames.peril.client.events.CreateGameServerRequestEvent;
 import com.forerunnergames.peril.client.events.CreateGameServerSuccessEvent;
-import com.forerunnergames.peril.client.events.DisconnectFromServerEvent;
+import com.forerunnergames.peril.client.events.DisconnectFromServerDebugEvent;
 import com.forerunnergames.peril.client.events.QuitGameEvent;
 import com.forerunnergames.peril.client.events.RejoinGameErrorEvent;
 import com.forerunnergames.peril.client.io.CachedGameSessionManager;
@@ -164,7 +164,7 @@ public final class MultiplayerController extends ControllerAdapter
 
   // TODO Production: Remove.
   @Handler
-  public void onEvent (final DisconnectFromServerEvent event)
+  public void onEvent (final DisconnectFromServerDebugEvent event)
   {
     Arguments.checkIsNotNull (event, "event");
 

--- a/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/intelbox/DefaultIntelBox.java
+++ b/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/intelbox/DefaultIntelBox.java
@@ -12,6 +12,7 @@ import com.badlogic.gdx.utils.Align;
 import com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.ClassicModePlayScreenWidgetFactory;
 import com.forerunnergames.peril.client.ui.widgets.personicons.PersonIcon;
 import com.forerunnergames.peril.client.ui.widgets.personicons.players.PlayerIcon;
+import com.forerunnergames.peril.common.game.GamePhase;
 import com.forerunnergames.peril.common.net.GameServerConfiguration;
 import com.forerunnergames.peril.common.net.packets.person.PersonPacket;
 import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
@@ -273,11 +274,11 @@ public final class DefaultIntelBox implements IntelBox
   }
 
   @Override
-  public void setGamePhaseName (final String phaseName)
+  public void setGamePhase (final GamePhase phase)
   {
-    Arguments.checkIsNotNull (phaseName, "phaseName");
+    Arguments.checkIsNotNull (phase, "phase");
 
-    gamePhaseTextLabel.setText (phaseName);
+    gamePhaseTextLabel.setText (asText (phase));
   }
 
   @Override
@@ -382,6 +383,58 @@ public final class DefaultIntelBox implements IntelBox
     detailedReportButtonLabel.setStyle (widgetFactory.createIntelBoxButtonTextLabelStyle ());
     detailedReportButton.setStyle (widgetFactory.createIntelBoxDetailedReportButtonStyle ());
     personIcon.refreshAssets ();
+  }
+
+  private String asText (final GamePhase phase)
+  {
+    switch (phase)
+    {
+      case INITIAL:
+      {
+        return "Starting...";
+      }
+      case INITIAL_COUNTRY_ASSIGNMENT:
+      {
+        return "Initial Country Assignment";
+      }
+      case INITIAL_REINFORCEMENT:
+      {
+        return "Initial Reinforcement";
+      }
+      case TURN:
+      {
+        // Should never be set, but just in case...
+        return "Turn";
+      }
+      case REINFORCEMENT:
+      {
+        return "Reinforcement";
+      }
+      case ATTACK:
+      {
+        return "Battle";
+      }
+      case FORTIFY:
+      {
+        return "Post-Combat Maneuver";
+      }
+      case END:
+      {
+        return "Game Over";
+      }
+      case SUSPENDED:
+      {
+        return "Game Paused";
+      }
+      case UNKNOWN:
+      {
+        return "?";
+      }
+      default:
+      {
+        return "?";
+      }
+    }
   }
 
   private boolean isSelf (@Nullable final PersonPacket person)

--- a/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/intelbox/IntelBox.java
+++ b/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/intelbox/IntelBox.java
@@ -2,6 +2,7 @@ package com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.inte
 
 import com.badlogic.gdx.scenes.scene2d.Actor;
 
+import com.forerunnergames.peril.common.game.GamePhase;
 import com.forerunnergames.peril.common.net.GameServerConfiguration;
 import com.forerunnergames.peril.common.net.packets.person.PersonPacket;
 import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
@@ -23,7 +24,7 @@ public interface IntelBox
 
   void setPlayMapMetadata (final PlayMapMetadata playMapMetadata);
 
-  void setGamePhaseName (final String phaseName);
+  void setGamePhase (final GamePhase phase);
 
   void setGameRound (final int round);
 

--- a/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/phasehandlers/AbstractBattlePhaseHandler.java
+++ b/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/phasehandlers/AbstractBattlePhaseHandler.java
@@ -23,6 +23,7 @@ import com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.dialo
 import com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.dialogs.battle.result.BattleResultDialog;
 import com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.playmap.actors.PlayMap;
 import com.forerunnergames.peril.common.game.BattleOutcome;
+import com.forerunnergames.peril.common.game.GamePhase;
 import com.forerunnergames.peril.common.net.events.client.interfaces.BattleRequestEvent;
 import com.forerunnergames.peril.common.net.events.client.request.inform.PlayerEndAttackPhaseRequestEvent;
 import com.forerunnergames.peril.common.net.events.client.request.inform.PlayerRetreatRequestEvent;
@@ -32,18 +33,16 @@ import com.forerunnergames.peril.common.net.packets.battle.BattleResultPacket;
 import com.forerunnergames.tools.common.Arguments;
 import com.forerunnergames.tools.common.Event;
 
+import com.google.common.collect.ImmutableSet;
+
 import javax.annotation.Nullable;
 import javax.annotation.OverridingMethodsMustInvokeSuper;
 
 import net.engio.mbassy.bus.MBassador;
 import net.engio.mbassy.listener.Handler;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 abstract class AbstractBattlePhaseHandler extends AbstractGamePhaseHandler implements BattlePhaseHandler
 {
-  protected final Logger log = LoggerFactory.getLogger (getClass ());
   private final BattleDialog battleDialog;
   private final BattleResultDialog resultDialog;
   @Nullable
@@ -61,19 +60,6 @@ abstract class AbstractBattlePhaseHandler extends AbstractGamePhaseHandler imple
 
     this.battleDialog = battleDialog;
     this.resultDialog = resultDialog;
-  }
-
-  @Override
-  public final void execute ()
-  {
-    Gdx.app.postRunnable (new Runnable ()
-    {
-      @Override
-      public void run ()
-      {
-        publish (createBattleRequestEvent (battleDialog.getActiveDieCount ()));
-      }
-    });
   }
 
   @Override
@@ -119,6 +105,25 @@ abstract class AbstractBattlePhaseHandler extends AbstractGamePhaseHandler imple
   {
     publish (new PlayerEndAttackPhaseRequestEvent ());
     reset ();
+  }
+
+  @Override
+  public ImmutableSet <GamePhase> getPhases ()
+  {
+    return ImmutableSet.of (GamePhase.ATTACK);
+  }
+
+  @Override
+  public final void execute ()
+  {
+    Gdx.app.postRunnable (new Runnable ()
+    {
+      @Override
+      public void run ()
+      {
+        publish (createBattleRequestEvent (battleDialog.getActiveDieCount ()));
+      }
+    });
   }
 
   @Override

--- a/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/phasehandlers/AbstractGamePhaseHandler.java
+++ b/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/phasehandlers/AbstractGamePhaseHandler.java
@@ -23,6 +23,7 @@ import com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.playm
 import com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.playmap.actors.PlayMap;
 import com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.playmap.images.CountryPrimaryImageState;
 import com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.playmap.input.listeners.PlayMapInputListener;
+import com.forerunnergames.peril.common.game.GamePhase;
 import com.forerunnergames.peril.common.game.PlayerColor;
 import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
 import com.forerunnergames.tools.common.Arguments;
@@ -35,8 +36,12 @@ import javax.annotation.OverridingMethodsMustInvokeSuper;
 
 import net.engio.mbassy.bus.MBassador;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 abstract class AbstractGamePhaseHandler implements GamePhaseHandler
 {
+  protected final Logger log = LoggerFactory.getLogger (getClass ());
   private final MBassador <Event> eventBus;
   private final PlayMapInputListener listener = new PlayMapInputListener ()
   {
@@ -83,26 +88,29 @@ abstract class AbstractGamePhaseHandler implements GamePhaseHandler
   }
 
   @Override
+  @OverridingMethodsMustInvokeSuper
   public void activate ()
   {
     eventBus.subscribe (this);
     reset ();
+    log.debug ("Activated [{}]", getClass ().getSimpleName ());
   }
 
   @Override
-  public void activateForSelf (final PlayerPacket player)
+  public final void activate (final GamePhase currentPhase)
   {
-    Arguments.checkIsNotNull (player, "player");
+    Arguments.checkIsNotNull (currentPhase, "phase");
 
-    if (isSelf (player)) activate ();
+    if (shouldActivateAndDeactivate (currentPhase)) activate ();
   }
 
   @Override
-  public void activateForEveryoneElse (final PlayerPacket player)
+  public final void activate (final PlayerPacket currentPlayer, final GamePhase currentPhase)
   {
-    Arguments.checkIsNotNull (player, "player");
+    Arguments.checkIsNotNull (currentPlayer, "player");
+    Arguments.checkIsNotNull (currentPhase, "phase");
 
-    if (!isSelf (player)) activate ();
+    if (shouldActivateAndDeactivate (currentPlayer, currentPhase)) activate ();
   }
 
   @Override
@@ -112,46 +120,44 @@ abstract class AbstractGamePhaseHandler implements GamePhaseHandler
   }
 
   @Override
+  @OverridingMethodsMustInvokeSuper
   public void deactivate ()
   {
     eventBus.unsubscribe (this);
     reset ();
+    log.debug ("Deactivated [{}]", getClass ().getSimpleName ());
   }
 
   @Override
-  public void deactivateForSelf (final PlayerPacket player)
+  public final void deactivate (final GamePhase currentPhase)
   {
-    Arguments.checkIsNotNull (player, "player");
+    Arguments.checkIsNotNull (currentPhase, "phase");
 
-    if (isSelf (player)) deactivate ();
+    if (shouldActivateAndDeactivate (currentPhase)) deactivate ();
   }
 
   @Override
-  public void deactivateForEveryoneElse (final PlayerPacket player)
+  public final void deactivate (final PlayerPacket currentPlayer, final GamePhase currentPhase)
   {
-    Arguments.checkIsNotNull (player, "player");
+    Arguments.checkIsNotNull (currentPlayer, "player");
+    Arguments.checkIsNotNull (currentPhase, "phase");
 
-    if (!isSelf (player)) deactivate ();
+    if (shouldActivateAndDeactivate (currentPlayer, currentPhase)) deactivate ();
   }
 
-  @Override
-  @OverridingMethodsMustInvokeSuper
-  public void setPlayMap (final PlayMap playMap)
+  // Default implementation checks if current game phase is one of the relevant phases for this handler,
+  // which makes sense for the majority of implementations.
+  protected boolean shouldActivateAndDeactivate (final GamePhase currentPhase)
   {
-    Arguments.checkIsNotNull (playMap, "playMap");
+    return getPhases ().contains (currentPhase);
+  }
 
-    final PlayMap oldPlayMap = this.playMap;
-
-    Gdx.app.postRunnable (new Runnable ()
-    {
-      @Override
-      public void run ()
-      {
-        oldPlayMap.removeListener (listener);
-      }
-    });
-
-    this.playMap = playMap;
+  // Default implementation checks if current player is the self player &
+  // current game phase is one of the relevant phases for this handler,
+  // which makes sense for the majority of implementations.
+  protected boolean shouldActivateAndDeactivate (final PlayerPacket currentPlayer, final GamePhase currentPhase)
+  {
+    return isSelf (currentPlayer) && getPhases ().contains (currentPhase);
   }
 
   final void listenForPlayMapCountryClicks ()
@@ -270,7 +276,7 @@ abstract class AbstractGamePhaseHandler implements GamePhaseHandler
   }
 
   @Override
-  public void updatePlayerForSelf (final PlayerPacket player)
+  public final void updatePlayerForSelf (final PlayerPacket player)
   {
     if (!isSelf (player)) return;
 
@@ -289,6 +295,33 @@ abstract class AbstractGamePhaseHandler implements GamePhaseHandler
         playMap.removeListener (listener);
       }
     });
+  }
+
+  @Override
+  public final void shutDown ()
+  {
+    deactivate ();
+    reset ();
+  }
+
+  @Override
+  @OverridingMethodsMustInvokeSuper
+  public void setPlayMap (final PlayMap playMap)
+  {
+    Arguments.checkIsNotNull (playMap, "playMap");
+
+    final PlayMap oldPlayMap = this.playMap;
+
+    Gdx.app.postRunnable (new Runnable ()
+    {
+      @Override
+      public void run ()
+      {
+        oldPlayMap.removeListener (listener);
+      }
+    });
+
+    this.playMap = playMap;
   }
 
   final String getSelfPlayerName ()

--- a/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/phasehandlers/BattlePhaseHandler.java
+++ b/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/phasehandlers/BattlePhaseHandler.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright © 2017 Forerunner Games, LLC.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.phasehandlers;
 
 import com.forerunnergames.peril.common.net.packets.battle.BattleResultPacket;

--- a/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/phasehandlers/CompositeGamePhaseHandler.java
+++ b/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/phasehandlers/CompositeGamePhaseHandler.java
@@ -18,8 +18,11 @@
 package com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.phasehandlers;
 
 import com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.playmap.actors.PlayMap;
+import com.forerunnergames.peril.common.game.GamePhase;
 import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
 import com.forerunnergames.tools.common.Arguments;
+
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -38,6 +41,19 @@ public final class CompositeGamePhaseHandler implements GamePhaseHandler
   }
 
   @Override
+  public ImmutableSet <GamePhase> getPhases ()
+  {
+    final ImmutableSet.Builder <GamePhase> phases = ImmutableSet.builder ();
+
+    for (final GamePhaseHandler handler : handlers)
+    {
+      phases.addAll (handler.getPhases ());
+    }
+
+    return phases.build ();
+  }
+
+  @Override
   public void activate ()
   {
     for (final GamePhaseHandler handler : handlers)
@@ -47,24 +63,25 @@ public final class CompositeGamePhaseHandler implements GamePhaseHandler
   }
 
   @Override
-  public void activateForSelf (final PlayerPacket player)
+  public void activate (final GamePhase currentPhase)
   {
-    Arguments.checkIsNotNull (player, "player");
+    Arguments.checkIsNotNull (currentPhase, "phase");
 
     for (final GamePhaseHandler handler : handlers)
     {
-      handler.activateForSelf (player);
+      handler.activate (currentPhase);
     }
   }
 
   @Override
-  public void activateForEveryoneElse (final PlayerPacket player)
+  public void activate (final PlayerPacket currentPlayer, final GamePhase currentPhase)
   {
-    Arguments.checkIsNotNull (player, "player");
+    Arguments.checkIsNotNull (currentPlayer, "player");
+    Arguments.checkIsNotNull (currentPhase, "phase");
 
     for (final GamePhaseHandler handler : handlers)
     {
-      handler.activateForEveryoneElse (player);
+      handler.activate (currentPlayer, currentPhase);
     }
   }
 
@@ -96,35 +113,25 @@ public final class CompositeGamePhaseHandler implements GamePhaseHandler
   }
 
   @Override
-  public void deactivateForSelf (final PlayerPacket player)
+  public void deactivate (final GamePhase currentPhase)
   {
-    Arguments.checkIsNotNull (player, "player");
+    Arguments.checkIsNotNull (currentPhase, "phase");
 
     for (final GamePhaseHandler handler : handlers)
     {
-      handler.deactivateForSelf (player);
+      handler.deactivate (currentPhase);
     }
   }
 
   @Override
-  public void deactivateForEveryoneElse (final PlayerPacket player)
+  public void deactivate (final PlayerPacket currentPlayer, final GamePhase currentPhase)
   {
-    Arguments.checkIsNotNull (player, "player");
+    Arguments.checkIsNotNull (currentPlayer, "player");
+    Arguments.checkIsNotNull (currentPhase, "phase");
 
     for (final GamePhaseHandler handler : handlers)
     {
-      handler.deactivateForEveryoneElse (player);
-    }
-  }
-
-  @Override
-  public void setPlayMap (final PlayMap playMap)
-  {
-    Arguments.checkIsNotNull (playMap, "playMap");
-
-    for (final GamePhaseHandler handler : handlers)
-    {
-      handler.setPlayMap (playMap);
+      handler.deactivate (currentPlayer, currentPhase);
     }
   }
 
@@ -156,6 +163,26 @@ public final class CompositeGamePhaseHandler implements GamePhaseHandler
     for (final GamePhaseHandler handler : handlers)
     {
       handler.reset ();
+    }
+  }
+
+  @Override
+  public void shutDown ()
+  {
+    for (final GamePhaseHandler handler : handlers)
+    {
+      handler.shutDown ();
+    }
+  }
+
+  @Override
+  public void setPlayMap (final PlayMap playMap)
+  {
+    Arguments.checkIsNotNull (playMap, "playMap");
+
+    for (final GamePhaseHandler handler : handlers)
+    {
+      handler.setPlayMap (playMap);
     }
   }
 

--- a/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/phasehandlers/DefendingBattlePhaseHandler.java
+++ b/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/phasehandlers/DefendingBattlePhaseHandler.java
@@ -20,10 +20,12 @@ package com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.phas
 import com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.dialogs.battle.BattleDialog;
 import com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.dialogs.battle.result.BattleResultDialog;
 import com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.playmap.actors.PlayMap;
+import com.forerunnergames.peril.common.game.GamePhase;
 import com.forerunnergames.peril.common.net.events.client.interfaces.BattleRequestEvent;
 import com.forerunnergames.peril.common.net.events.client.request.response.PlayerDefendCountryResponseRequestEvent;
 import com.forerunnergames.peril.common.net.events.server.denied.PlayerDefendCountryResponseDeniedEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerRetreatSuccessEvent;
+import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
 import com.forerunnergames.tools.common.Arguments;
 import com.forerunnergames.tools.common.Event;
 
@@ -44,6 +46,12 @@ public final class DefendingBattlePhaseHandler extends AbstractBattlePhaseHandle
   protected BattleRequestEvent createBattleRequestEvent (final int dieCount)
   {
     return new PlayerDefendCountryResponseRequestEvent (dieCount);
+  }
+
+  @Override
+  protected boolean shouldActivateAndDeactivate (final PlayerPacket currentPlayer, final GamePhase currentPhase)
+  {
+    return !isSelf (currentPlayer) && getPhases ().contains (currentPhase);
   }
 
   @Handler

--- a/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/phasehandlers/FortificationPhaseHandler.java
+++ b/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/phasehandlers/FortificationPhaseHandler.java
@@ -24,29 +24,28 @@ import com.forerunnergames.peril.client.events.SelectFortifySourceCountryRequest
 import com.forerunnergames.peril.client.events.SelectFortifyTargetCountryRequestEvent;
 import com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.dialogs.armymovement.fortification.FortificationDialog;
 import com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.playmap.actors.PlayMap;
+import com.forerunnergames.peril.common.game.GamePhase;
 import com.forerunnergames.peril.common.net.events.client.request.inform.PlayerCancelFortifyRequestEvent;
 import com.forerunnergames.peril.common.net.events.client.request.inform.PlayerFortifyCountryRequestEvent;
 import com.forerunnergames.peril.common.net.events.client.request.inform.PlayerSelectFortifyVectorRequestEvent;
 import com.forerunnergames.peril.common.net.events.server.denied.PlayerCancelFortifyDeniedEvent;
 import com.forerunnergames.peril.common.net.events.server.denied.PlayerFortifyCountryDeniedEvent;
 import com.forerunnergames.peril.common.net.events.server.denied.PlayerSelectFortifyVectorDeniedEvent;
-import com.forerunnergames.peril.common.net.events.server.inform.PlayerSelectFortifyVectorEvent;
 import com.forerunnergames.peril.common.net.events.server.inform.PlayerFortifyCountryEvent;
+import com.forerunnergames.peril.common.net.events.server.inform.PlayerSelectFortifyVectorEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerCancelFortifySuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerFortifyCountrySuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerSelectFortifyVectorSuccessEvent;
 import com.forerunnergames.tools.common.Arguments;
 import com.forerunnergames.tools.common.Event;
 
+import com.google.common.collect.ImmutableSet;
+
 import net.engio.mbassy.bus.MBassador;
 import net.engio.mbassy.listener.Handler;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public final class FortificationPhaseHandler extends AbstractGamePhaseHandler
 {
-  private static final Logger log = LoggerFactory.getLogger (FortificationPhaseHandler.class);
   private final CountryVectorSelectionHandler countryVectorSelectionHandler;
   private final FortificationDialog fortificationDialog;
 
@@ -60,6 +59,12 @@ public final class FortificationPhaseHandler extends AbstractGamePhaseHandler
 
     this.fortificationDialog = fortificationDialog;
     countryVectorSelectionHandler = new FortificationPhaseCountryVectorSelectionHandler (playMap, eventBus);
+  }
+
+  @Override
+  public ImmutableSet <GamePhase> getPhases ()
+  {
+    return ImmutableSet.of (GamePhase.FORTIFY);
   }
 
   @Override

--- a/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/phasehandlers/GamePhaseHandler.java
+++ b/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/phasehandlers/GamePhaseHandler.java
@@ -18,7 +18,10 @@
 package com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.phasehandlers;
 
 import com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.playmap.actors.PlayMap;
+import com.forerunnergames.peril.common.game.GamePhase;
 import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
+
+import com.google.common.collect.ImmutableSet;
 
 /**
  * Handles game logic for various game phases.
@@ -28,28 +31,36 @@ public interface GamePhaseHandler
   GamePhaseHandler NULL = new NullGamePhaseHandler ();
 
   /**
-   * Enable the handler. Call before performing game phase logic via {@link #execute()}, such as when the necessary game
-   * phase becomes active, which will allow the handler to begin listening for events, for example. GamePhaseHandler's
-   * can be re-used after activation by calling {@link #reset()}. Or {@link #reset()} can be called from within this
-   * method.
+   * Gets the game phases this handler is valid / responsible for.
+   */
+  ImmutableSet <GamePhase> getPhases ();
+
+  /**
+   * Unconditionally enable the handler. Call before performing game phase logic via {@link #execute()}, such as when
+   * the necessary game phase becomes active, which will allow the handler to begin listening for events, for example.
+   * GamePhaseHandler's can be re-used after activation by calling {@link #reset()}. Or {@link #reset()} can be called
+   * from within this method.
+   *
+   * @see #activate(GamePhase)
+   * @see #activate(PlayerPacket, GamePhase)
    */
   void activate ();
 
   /**
-   * Enable the handler only if the specified {@link PlayerPacket} matches the player previously set by
-   * {@link #setSelfPlayer(PlayerPacket)}.
+   * Conditionally enable the handler, depending on whether it is appropriate to do so with respect to the specified
+   * current game phase.
    *
-   * @see #activate() ()
+   * @see #activate() for more information.
    */
-  void activateForSelf (final PlayerPacket player);
+  void activate (final GamePhase currentPhase);
 
   /**
-   * Enable the handler only if the specified {@link PlayerPacket} does *not* match the player previously set by
-   * {@link #setSelfPlayer(PlayerPacket)}.
+   * Conditionally enable the handler, depending on whether it is appropriate to do so with respect to the specified
+   * current player & specified current game phase.
    *
-   * @see #activate()
+   * @see #activate() for more information.
    */
-  void activateForEveryoneElse (final PlayerPacket player);
+  void activate (final PlayerPacket currentPlayer, final GamePhase currentPhase);
 
   /**
    * Perform the game phase logic here, after calling {@link #activate}.
@@ -63,30 +74,31 @@ public interface GamePhaseHandler
   void cancel ();
 
   /**
-   * Disable the handler. Call when finished performing game phase logic via {@link #execute()}, such as when the
-   * necessary game phase is no longer active, which will prevent the handler from listening for events when it
+   * Unconditionally disable the handler. Call when finished performing game phase logic via {@link #execute()}, such as
+   * when the necessary game phase is no longer active, which will prevent the handler from listening for events when it
    * shouldn't, for example. GamePhaseHandler's can be re-used after deactivation by calling {@link #reset()}, then one
    * of the {@link #activate()} methods again.
+   *
+   * @see #deactivate(GamePhase)
+   * @see #deactivate(PlayerPacket, GamePhase)
    */
   void deactivate ();
 
   /**
-   * Disable the handler only if the specified {@link PlayerPacket} matches the player previously set by
-   * {@link #setSelfPlayer(PlayerPacket)}.
+   * Conditionally disable the handler, depending on whether it is appropriate to do so with respect to the specified
+   * current game phase.
    *
-   * @see #deactivate()
+   * @see #deactivate() for more information.
    */
-  void deactivateForSelf (final PlayerPacket player);
+  void deactivate (final GamePhase currentPhase);
 
   /**
-   * Disable the handler only if the specified {@link PlayerPacket} does *not* match the player previously set by
-   * {@link #setSelfPlayer(PlayerPacket)}.
+   * Conditionally disable the handler, depending on whether it is appropriate to do so with respect to the specified
+   * current player & specified current game phase.
    *
-   * @see #deactivate()
+   * @see #deactivate() for more information.
    */
-  void deactivateForEveryoneElse (final PlayerPacket player);
-
-  void setPlayMap (final PlayMap playMap);
+  void deactivate (final PlayerPacket currentPlayer, final GamePhase currentPhase);
 
   /**
    * Set the player identity of this handler. Allows for conditional activation / deactivation based on a
@@ -110,4 +122,14 @@ public interface GamePhaseHandler
    * status.
    */
   void reset ();
+
+  /**
+   * Calls {@link #deactivate()} then {@link #reset()}. Can be re-used by calling {@link #activate()} again.
+   */
+  void shutDown ();
+
+  /**
+   * Sets the specified {@link PlayMap} to be the current play map.
+   */
+  void setPlayMap (final PlayMap playMap);
 }

--- a/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/phasehandlers/InitialCountryAssignmentPhaseHandler.java
+++ b/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/phasehandlers/InitialCountryAssignmentPhaseHandler.java
@@ -3,6 +3,7 @@ package com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.phas
 import com.badlogic.gdx.Gdx;
 
 import com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.playmap.actors.PlayMap;
+import com.forerunnergames.peril.common.game.GamePhase;
 import com.forerunnergames.peril.common.game.PlayerColor;
 import com.forerunnergames.peril.common.net.events.client.request.response.PlayerClaimCountryResponseRequestEvent;
 import com.forerunnergames.peril.common.net.events.server.denied.PlayerClaimCountryResponseDeniedEvent;
@@ -13,21 +14,19 @@ import com.forerunnergames.tools.common.Event;
 import com.forerunnergames.tools.common.Result;
 import com.forerunnergames.tools.common.Strings;
 
+import com.google.common.collect.ImmutableSet;
+
 import javax.annotation.Nullable;
 
 import net.engio.mbassy.bus.MBassador;
 import net.engio.mbassy.listener.Handler;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-public final class ManualCountryAssignmentPhaseHandler extends AbstractGamePhaseHandler
+public final class InitialCountryAssignmentPhaseHandler extends AbstractGamePhaseHandler
 {
-  private static final Logger log = LoggerFactory.getLogger (ManualCountryAssignmentPhaseHandler.class);
   @Nullable
   private PlayerClaimCountryRequestEvent request = null;
 
-  public ManualCountryAssignmentPhaseHandler (final PlayMap playMap, final MBassador <Event> eventBus)
+  public InitialCountryAssignmentPhaseHandler (final PlayMap playMap, final MBassador <Event> eventBus)
   {
     super (playMap, eventBus);
   }
@@ -48,6 +47,12 @@ public final class ManualCountryAssignmentPhaseHandler extends AbstractGamePhase
   {
     super.reset ();
     request = null;
+  }
+
+  @Override
+  public ImmutableSet <GamePhase> getPhases ()
+  {
+    return ImmutableSet.of (GamePhase.INITIAL_COUNTRY_ASSIGNMENT);
   }
 
   @Override

--- a/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/phasehandlers/NullGamePhaseHandler.java
+++ b/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/phasehandlers/NullGamePhaseHandler.java
@@ -18,26 +18,36 @@
 package com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.phasehandlers;
 
 import com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.playmap.actors.PlayMap;
+import com.forerunnergames.peril.common.game.GamePhase;
 import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
 import com.forerunnergames.tools.common.Arguments;
 
+import com.google.common.collect.ImmutableSet;
+
 class NullGamePhaseHandler implements GamePhaseHandler
 {
+  @Override
+  public ImmutableSet <GamePhase> getPhases ()
+  {
+    return ImmutableSet.of ();
+  }
+
   @Override
   public final void activate ()
   {
   }
 
   @Override
-  public final void activateForSelf (final PlayerPacket player)
+  public void activate (final GamePhase currentPhase)
   {
-    Arguments.checkIsNotNull (player, "player");
+    Arguments.checkIsNotNull (currentPhase, "currentPhase");
   }
 
   @Override
-  public final void activateForEveryoneElse (final PlayerPacket player)
+  public void activate (final PlayerPacket currentPlayer, final GamePhase currentPhase)
   {
-    Arguments.checkIsNotNull (player, "player");
+    Arguments.checkIsNotNull (currentPlayer, "currentPlayer");
+    Arguments.checkIsNotNull (currentPhase, "currentPhase");
   }
 
   @Override
@@ -56,21 +66,16 @@ class NullGamePhaseHandler implements GamePhaseHandler
   }
 
   @Override
-  public final void deactivateForSelf (final PlayerPacket player)
+  public void deactivate (final GamePhase currentPhase)
   {
-    Arguments.checkIsNotNull (player, "player");
+    Arguments.checkIsNotNull (currentPhase, "currentPhase");
   }
 
   @Override
-  public final void deactivateForEveryoneElse (final PlayerPacket player)
+  public void deactivate (final PlayerPacket currentPlayer, final GamePhase currentPhase)
   {
-    Arguments.checkIsNotNull (player, "player");
-  }
-
-  @Override
-  public final void setPlayMap (final PlayMap playMap)
-  {
-    Arguments.checkIsNotNull (playMap, "playMap");
+    Arguments.checkIsNotNull (currentPlayer, "currentPlayer");
+    Arguments.checkIsNotNull (currentPhase, "currentPhase");
   }
 
   @Override
@@ -88,5 +93,16 @@ class NullGamePhaseHandler implements GamePhaseHandler
   @Override
   public final void reset ()
   {
+  }
+
+  @Override
+  public void shutDown ()
+  {
+  }
+
+  @Override
+  public final void setPlayMap (final PlayMap playMap)
+  {
+    Arguments.checkIsNotNull (playMap, "playMap");
   }
 }

--- a/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/phasehandlers/OccupationPhaseHandler.java
+++ b/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/phasehandlers/OccupationPhaseHandler.java
@@ -19,6 +19,7 @@ package com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.phas
 
 import com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.dialogs.armymovement.occupation.OccupationDialog;
 import com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.playmap.actors.PlayMap;
+import com.forerunnergames.peril.common.game.GamePhase;
 import com.forerunnergames.peril.common.net.events.client.request.response.PlayerOccupyCountryResponseRequestEvent;
 import com.forerunnergames.peril.common.net.events.server.denied.PlayerOccupyCountryResponseDeniedEvent;
 import com.forerunnergames.peril.common.net.events.server.request.PlayerOccupyCountryRequestEvent;
@@ -26,17 +27,15 @@ import com.forerunnergames.peril.common.net.events.server.success.PlayerOccupyCo
 import com.forerunnergames.tools.common.Arguments;
 import com.forerunnergames.tools.common.Event;
 
+import com.google.common.collect.ImmutableSet;
+
 import javax.annotation.Nullable;
 
 import net.engio.mbassy.bus.MBassador;
 import net.engio.mbassy.listener.Handler;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public final class OccupationPhaseHandler extends AbstractGamePhaseHandler
 {
-  private static final Logger log = LoggerFactory.getLogger (OccupationPhaseHandler.class);
   private final OccupationDialog occupationDialog;
   @Nullable
   private PlayerOccupyCountryRequestEvent request = null;
@@ -56,6 +55,12 @@ public final class OccupationPhaseHandler extends AbstractGamePhaseHandler
     Arguments.checkIsNotNull (occupationDialog, "occupationDialog");
 
     this.occupationDialog = occupationDialog;
+  }
+
+  @Override
+  public ImmutableSet <GamePhase> getPhases ()
+  {
+    return ImmutableSet.of (GamePhase.ATTACK);
   }
 
   @Override

--- a/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/phasehandlers/ReinforcementPhaseHandler.java
+++ b/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/phasehandlers/ReinforcementPhaseHandler.java
@@ -20,6 +20,7 @@ package com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.phas
 import com.badlogic.gdx.Gdx;
 
 import com.forerunnergames.peril.client.ui.screens.game.play.modes.classic.playmap.actors.PlayMap;
+import com.forerunnergames.peril.common.game.GamePhase;
 import com.forerunnergames.peril.common.net.events.client.request.inform.PlayerReinforceCountryRequestEvent;
 import com.forerunnergames.peril.common.net.events.server.denied.PlayerReinforceCountryDeniedEvent;
 import com.forerunnergames.peril.common.net.events.server.inform.PlayerReinforceCountryEvent;
@@ -29,17 +30,15 @@ import com.forerunnergames.tools.common.Event;
 import com.forerunnergames.tools.common.Result;
 import com.forerunnergames.tools.common.Strings;
 
+import com.google.common.collect.ImmutableSet;
+
 import javax.annotation.Nullable;
 
 import net.engio.mbassy.bus.MBassador;
 import net.engio.mbassy.listener.Handler;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public final class ReinforcementPhaseHandler extends AbstractGamePhaseHandler
 {
-  private static final Logger log = LoggerFactory.getLogger (ReinforcementPhaseHandler.class);
   private final ReinforcementDialog reinforcementDialog;
   @Nullable
   private PlayerReinforceCountryEvent serverInformEvent;
@@ -61,6 +60,12 @@ public final class ReinforcementPhaseHandler extends AbstractGamePhaseHandler
     Arguments.checkIsNotNull (reinforcementDialog, "reinforcementDialog");
 
     this.reinforcementDialog = reinforcementDialog;
+  }
+
+  @Override
+  public ImmutableSet <GamePhase> getPhases ()
+  {
+    return ImmutableSet.of (GamePhase.INITIAL_REINFORCEMENT, GamePhase.REINFORCEMENT);
   }
 
   @Override

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/defaults/AbstractGamePhaseNotificationEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/defaults/AbstractGamePhaseNotificationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Forerunner Games, LLC.
+ * Copyright © 2017 Forerunner Games, LLC.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,24 +15,40 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.forerunnergames.peril.common.net.events.server.notify.broadcast;
+package com.forerunnergames.peril.common.net.events.server.defaults;
 
 import com.forerunnergames.peril.common.game.GamePhase;
-import com.forerunnergames.peril.common.net.events.server.defaults.AbstractGamePhaseNotificationEvent;
-import com.forerunnergames.peril.common.net.events.server.interfaces.EndGamePhaseNotificationEvent;
+import com.forerunnergames.peril.common.net.events.server.interfaces.GamePhaseNotificationEvent;
+import com.forerunnergames.tools.common.Arguments;
+import com.forerunnergames.tools.common.Strings;
 import com.forerunnergames.tools.net.annotations.RequiredForNetworkSerialization;
 
-public final class ResumeGameEvent extends AbstractGamePhaseNotificationEvent implements EndGamePhaseNotificationEvent
+public abstract class AbstractGamePhaseNotificationEvent implements GamePhaseNotificationEvent
 {
-  @RequiredForNetworkSerialization
-  public ResumeGameEvent ()
+  private final GamePhase gamePhase;
+
+  protected AbstractGamePhaseNotificationEvent (final GamePhase gamePhase)
   {
-    super (GamePhase.SUSPENDED);
+    Arguments.checkIsNotNull (gamePhase, "gamePhase");
+
+    this.gamePhase = gamePhase;
+  }
+
+  @RequiredForNetworkSerialization
+  protected AbstractGamePhaseNotificationEvent ()
+  {
+    gamePhase = null;
+  }
+
+  @Override
+  public final GamePhase getGamePhase ()
+  {
+    return gamePhase;
   }
 
   @Override
   public String toString ()
   {
-    return getClass ().getSimpleName ();
+    return Strings.format ("{} | GamePhase: [{}]", getClass ().getSimpleName (), gamePhase);
   }
 }

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/defaults/AbstractPlayerGamePhaseNotificationEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/defaults/AbstractPlayerGamePhaseNotificationEvent.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2017 Forerunner Games, LLC.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.forerunnergames.peril.common.net.events.server.defaults;
+
+import com.forerunnergames.peril.common.game.GamePhase;
+import com.forerunnergames.peril.common.net.events.server.interfaces.PlayerGamePhaseNotificationEvent;
+import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
+import com.forerunnergames.tools.common.Arguments;
+import com.forerunnergames.tools.common.Strings;
+import com.forerunnergames.tools.net.annotations.RequiredForNetworkSerialization;
+
+public abstract class AbstractPlayerGamePhaseNotificationEvent extends AbstractPlayerEvent
+        implements PlayerGamePhaseNotificationEvent
+{
+  private final GamePhase gamePhase;
+
+  protected AbstractPlayerGamePhaseNotificationEvent (final PlayerPacket player, final GamePhase gamePhase)
+  {
+    super (player);
+
+    Arguments.checkIsNotNull (gamePhase, "gamePhase");
+
+    this.gamePhase = gamePhase;
+  }
+
+  @RequiredForNetworkSerialization
+  protected AbstractPlayerGamePhaseNotificationEvent ()
+  {
+    gamePhase = null;
+  }
+
+  @Override
+  public final GamePhase getGamePhase ()
+  {
+    return gamePhase;
+  }
+
+  @Override
+  public String toString ()
+  {
+    return Strings.format ("{} | GamePhase: [{}]", super.toString (), gamePhase);
+  }
+}

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/interfaces/BeginGamePhaseNotificationEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/interfaces/BeginGamePhaseNotificationEvent.java
@@ -15,18 +15,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.forerunnergames.peril.common.game;
+package com.forerunnergames.peril.common.net.events.server.interfaces;
 
-public enum GamePhase
+public interface BeginGamePhaseNotificationEvent extends GamePhaseNotificationEvent
 {
-  INITIAL,
-  INITIAL_COUNTRY_ASSIGNMENT,
-  INITIAL_REINFORCEMENT,
-  TURN,
-  REINFORCEMENT,
-  ATTACK,
-  FORTIFY,
-  END,
-  SUSPENDED,
-  UNKNOWN
 }

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/interfaces/EndGamePhaseNotificationEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/interfaces/EndGamePhaseNotificationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Forerunner Games, LLC.
+ * Copyright © 2017 Forerunner Games, LLC.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,11 +15,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.forerunnergames.peril.client.events;
+package com.forerunnergames.peril.common.net.events.server.interfaces;
 
-import com.forerunnergames.tools.net.events.local.LocalEvent;
-
-// TODO Production: Remove.
-public final class DisconnectFromServerEvent implements LocalEvent
+public interface EndGamePhaseNotificationEvent extends GamePhaseNotificationEvent
 {
 }

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/interfaces/GamePhaseNotificationEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/interfaces/GamePhaseNotificationEvent.java
@@ -15,18 +15,12 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.forerunnergames.peril.common.game;
+package com.forerunnergames.peril.common.net.events.server.interfaces;
 
-public enum GamePhase
+import com.forerunnergames.peril.common.game.GamePhase;
+import com.forerunnergames.tools.net.events.remote.origin.server.BroadcastNotificationEvent;
+
+public interface GamePhaseNotificationEvent extends BroadcastNotificationEvent
 {
-  INITIAL,
-  INITIAL_COUNTRY_ASSIGNMENT,
-  INITIAL_REINFORCEMENT,
-  TURN,
-  REINFORCEMENT,
-  ATTACK,
-  FORTIFY,
-  END,
-  SUSPENDED,
-  UNKNOWN
+  GamePhase getGamePhase ();
 }

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/interfaces/PlayerBeginGamePhaseNotificationEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/interfaces/PlayerBeginGamePhaseNotificationEvent.java
@@ -15,18 +15,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.forerunnergames.peril.common.game;
+package com.forerunnergames.peril.common.net.events.server.interfaces;
 
-public enum GamePhase
+public interface PlayerBeginGamePhaseNotificationEvent
+        extends PlayerGamePhaseNotificationEvent, BeginGamePhaseNotificationEvent
 {
-  INITIAL,
-  INITIAL_COUNTRY_ASSIGNMENT,
-  INITIAL_REINFORCEMENT,
-  TURN,
-  REINFORCEMENT,
-  ATTACK,
-  FORTIFY,
-  END,
-  SUSPENDED,
-  UNKNOWN
 }

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/interfaces/PlayerEndGamePhaseNotificationEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/interfaces/PlayerEndGamePhaseNotificationEvent.java
@@ -15,18 +15,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.forerunnergames.peril.common.game;
+package com.forerunnergames.peril.common.net.events.server.interfaces;
 
-public enum GamePhase
+public interface PlayerEndGamePhaseNotificationEvent
+        extends PlayerGamePhaseNotificationEvent, EndGamePhaseNotificationEvent
 {
-  INITIAL,
-  INITIAL_COUNTRY_ASSIGNMENT,
-  INITIAL_REINFORCEMENT,
-  TURN,
-  REINFORCEMENT,
-  ATTACK,
-  FORTIFY,
-  END,
-  SUSPENDED,
-  UNKNOWN
 }

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/interfaces/PlayerGamePhaseNotificationEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/interfaces/PlayerGamePhaseNotificationEvent.java
@@ -15,18 +15,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.forerunnergames.peril.common.game;
+package com.forerunnergames.peril.common.net.events.server.interfaces;
 
-public enum GamePhase
+public interface PlayerGamePhaseNotificationEvent extends PlayerEvent, GamePhaseNotificationEvent
 {
-  INITIAL,
-  INITIAL_COUNTRY_ASSIGNMENT,
-  INITIAL_REINFORCEMENT,
-  TURN,
-  REINFORCEMENT,
-  ATTACK,
-  FORTIFY,
-  END,
-  SUSPENDED,
-  UNKNOWN
 }

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/interfaces/PlayerSkipGamePhaseNotificationEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/interfaces/PlayerSkipGamePhaseNotificationEvent.java
@@ -15,18 +15,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.forerunnergames.peril.common.game;
+package com.forerunnergames.peril.common.net.events.server.interfaces;
 
-public enum GamePhase
+public interface PlayerSkipGamePhaseNotificationEvent extends PlayerEvent, GamePhaseNotificationEvent
 {
-  INITIAL,
-  INITIAL_COUNTRY_ASSIGNMENT,
-  INITIAL_REINFORCEMENT,
-  TURN,
-  REINFORCEMENT,
-  ATTACK,
-  FORTIFY,
-  END,
-  SUSPENDED,
-  UNKNOWN
 }

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/interfaces/SkipGamePhaseNotificationEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/interfaces/SkipGamePhaseNotificationEvent.java
@@ -15,18 +15,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.forerunnergames.peril.common.game;
+package com.forerunnergames.peril.common.net.events.server.interfaces;
 
-public enum GamePhase
+public interface SkipGamePhaseNotificationEvent extends GamePhaseNotificationEvent
 {
-  INITIAL,
-  INITIAL_COUNTRY_ASSIGNMENT,
-  INITIAL_REINFORCEMENT,
-  TURN,
-  REINFORCEMENT,
-  ATTACK,
-  FORTIFY,
-  END,
-  SUSPENDED,
-  UNKNOWN
 }

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/BeginAttackPhaseEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/BeginAttackPhaseEvent.java
@@ -18,16 +18,18 @@
 
 package com.forerunnergames.peril.common.net.events.server.notify.broadcast;
 
-import com.forerunnergames.peril.common.net.events.server.defaults.AbstractPlayerEvent;
+import com.forerunnergames.peril.common.game.GamePhase;
+import com.forerunnergames.peril.common.net.events.server.defaults.AbstractPlayerGamePhaseNotificationEvent;
+import com.forerunnergames.peril.common.net.events.server.interfaces.PlayerBeginGamePhaseNotificationEvent;
 import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
 import com.forerunnergames.tools.net.annotations.RequiredForNetworkSerialization;
-import com.forerunnergames.tools.net.events.remote.origin.server.BroadcastNotificationEvent;
 
-public final class BeginAttackPhaseEvent extends AbstractPlayerEvent implements BroadcastNotificationEvent
+public final class BeginAttackPhaseEvent extends AbstractPlayerGamePhaseNotificationEvent
+        implements PlayerBeginGamePhaseNotificationEvent
 {
   public BeginAttackPhaseEvent (final PlayerPacket currentPlayer)
   {
-    super (currentPlayer);
+    super (currentPlayer, GamePhase.ATTACK);
   }
 
   @RequiredForNetworkSerialization

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/BeginFortifyPhaseEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/BeginFortifyPhaseEvent.java
@@ -18,16 +18,18 @@
 
 package com.forerunnergames.peril.common.net.events.server.notify.broadcast;
 
-import com.forerunnergames.peril.common.net.events.server.defaults.AbstractPlayerEvent;
+import com.forerunnergames.peril.common.game.GamePhase;
+import com.forerunnergames.peril.common.net.events.server.defaults.AbstractPlayerGamePhaseNotificationEvent;
+import com.forerunnergames.peril.common.net.events.server.interfaces.PlayerBeginGamePhaseNotificationEvent;
 import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
 import com.forerunnergames.tools.net.annotations.RequiredForNetworkSerialization;
-import com.forerunnergames.tools.net.events.remote.origin.server.BroadcastNotificationEvent;
 
-public final class BeginFortifyPhaseEvent extends AbstractPlayerEvent implements BroadcastNotificationEvent
+public final class BeginFortifyPhaseEvent extends AbstractPlayerGamePhaseNotificationEvent
+        implements PlayerBeginGamePhaseNotificationEvent
 {
   public BeginFortifyPhaseEvent (final PlayerPacket player)
   {
-    super (player);
+    super (player, GamePhase.FORTIFY);
   }
 
   @RequiredForNetworkSerialization

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/BeginGameEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/BeginGameEvent.java
@@ -17,13 +17,14 @@
 
 package com.forerunnergames.peril.common.net.events.server.notify.broadcast;
 
-import com.forerunnergames.tools.net.annotations.RequiredForNetworkSerialization;
-import com.forerunnergames.tools.net.events.remote.origin.server.BroadcastNotificationEvent;
+import com.forerunnergames.peril.common.game.GamePhase;
+import com.forerunnergames.peril.common.net.events.server.defaults.AbstractGamePhaseNotificationEvent;
+import com.forerunnergames.peril.common.net.events.server.interfaces.BeginGamePhaseNotificationEvent;
 
-public final class BeginGameEvent implements BroadcastNotificationEvent
+public final class BeginGameEvent extends AbstractGamePhaseNotificationEvent implements BeginGamePhaseNotificationEvent
 {
-  @RequiredForNetworkSerialization
   public BeginGameEvent ()
   {
+    super (GamePhase.INITIAL);
   }
 }

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/BeginInitialCountryAssignmentPhaseEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/BeginInitialCountryAssignmentPhaseEvent.java
@@ -18,18 +18,23 @@
 
 package com.forerunnergames.peril.common.net.events.server.notify.broadcast;
 
+import com.forerunnergames.peril.common.game.GamePhase;
 import com.forerunnergames.peril.common.game.InitialCountryAssignment;
+import com.forerunnergames.peril.common.net.events.server.defaults.AbstractGamePhaseNotificationEvent;
+import com.forerunnergames.peril.common.net.events.server.interfaces.BeginGamePhaseNotificationEvent;
 import com.forerunnergames.tools.common.Arguments;
 import com.forerunnergames.tools.common.Strings;
 import com.forerunnergames.tools.net.annotations.RequiredForNetworkSerialization;
-import com.forerunnergames.tools.net.events.remote.origin.server.BroadcastNotificationEvent;
 
-public final class BeginPlayerCountryAssignmentEvent implements BroadcastNotificationEvent
+public final class BeginInitialCountryAssignmentPhaseEvent extends AbstractGamePhaseNotificationEvent
+        implements BeginGamePhaseNotificationEvent
 {
   private final InitialCountryAssignment assignmentMode;
 
-  public BeginPlayerCountryAssignmentEvent (final InitialCountryAssignment assignmentMode)
+  public BeginInitialCountryAssignmentPhaseEvent (final InitialCountryAssignment assignmentMode)
   {
+    super (GamePhase.INITIAL_COUNTRY_ASSIGNMENT);
+
     this.assignmentMode = assignmentMode;
   }
 
@@ -48,11 +53,11 @@ public final class BeginPlayerCountryAssignmentEvent implements BroadcastNotific
   @Override
   public String toString ()
   {
-    return Strings.format ("{}: AssignmentMode: {}", getClass ().getSimpleName (), assignmentMode);
+    return Strings.format ("{} | AssignmentMode: [{}]", super.toString (), assignmentMode);
   }
 
   @RequiredForNetworkSerialization
-  private BeginPlayerCountryAssignmentEvent ()
+  private BeginInitialCountryAssignmentPhaseEvent ()
   {
     assignmentMode = null;
   }

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/BeginInitialReinforcementPhaseEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/BeginInitialReinforcementPhaseEvent.java
@@ -18,20 +18,17 @@
 
 package com.forerunnergames.peril.common.net.events.server.notify.broadcast;
 
-import com.forerunnergames.peril.common.net.events.server.defaults.AbstractPlayerEvent;
-import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
+import com.forerunnergames.peril.common.game.GamePhase;
+import com.forerunnergames.peril.common.net.events.server.defaults.AbstractGamePhaseNotificationEvent;
+import com.forerunnergames.peril.common.net.events.server.interfaces.BeginGamePhaseNotificationEvent;
 import com.forerunnergames.tools.net.annotations.RequiredForNetworkSerialization;
-import com.forerunnergames.tools.net.events.remote.origin.server.BroadcastNotificationEvent;
 
-public final class BeginInitialReinforcementPhaseEvent extends AbstractPlayerEvent implements BroadcastNotificationEvent
+public final class BeginInitialReinforcementPhaseEvent extends AbstractGamePhaseNotificationEvent
+        implements BeginGamePhaseNotificationEvent
 {
-  public BeginInitialReinforcementPhaseEvent (final PlayerPacket currentPlayer)
-  {
-    super (currentPlayer);
-  }
-
   @RequiredForNetworkSerialization
-  private BeginInitialReinforcementPhaseEvent ()
+  public BeginInitialReinforcementPhaseEvent ()
   {
+    super (GamePhase.INITIAL_REINFORCEMENT);
   }
 }

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/BeginReinforcementPhaseEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/BeginReinforcementPhaseEvent.java
@@ -18,11 +18,15 @@
 
 package com.forerunnergames.peril.common.net.events.server.notify.broadcast;
 
+import com.forerunnergames.peril.common.game.GamePhase;
 import com.forerunnergames.peril.common.net.events.server.defaults.AbstractPlayerArmiesChangedEvent;
+import com.forerunnergames.peril.common.net.events.server.interfaces.PlayerBeginGamePhaseNotificationEvent;
 import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
+import com.forerunnergames.tools.common.Strings;
 import com.forerunnergames.tools.net.annotations.RequiredForNetworkSerialization;
 
 public final class BeginReinforcementPhaseEvent extends AbstractPlayerArmiesChangedEvent
+        implements PlayerBeginGamePhaseNotificationEvent
 {
   private final int countryReinforcementBonus;
   private final int continentReinforcementBonus;
@@ -37,6 +41,12 @@ public final class BeginReinforcementPhaseEvent extends AbstractPlayerArmiesChan
     this.continentReinforcementBonus = continentReinforcementBonus;
   }
 
+  @Override
+  public GamePhase getGamePhase ()
+  {
+    return GamePhase.REINFORCEMENT;
+  }
+
   public int getCountryReinforcementBonus ()
   {
     return countryReinforcementBonus;
@@ -45,6 +55,12 @@ public final class BeginReinforcementPhaseEvent extends AbstractPlayerArmiesChan
   public int getContinentReinforcementBonus ()
   {
     return continentReinforcementBonus;
+  }
+
+  @Override
+  public String toString ()
+  {
+    return Strings.format ("{} | GamePhase: [{}]", super.toString (), getGamePhase ());
   }
 
   @RequiredForNetworkSerialization

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/EndAttackPhaseEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/EndAttackPhaseEvent.java
@@ -18,16 +18,18 @@
 
 package com.forerunnergames.peril.common.net.events.server.notify.broadcast;
 
-import com.forerunnergames.peril.common.net.events.server.defaults.AbstractPlayerEvent;
+import com.forerunnergames.peril.common.game.GamePhase;
+import com.forerunnergames.peril.common.net.events.server.defaults.AbstractPlayerGamePhaseNotificationEvent;
+import com.forerunnergames.peril.common.net.events.server.interfaces.PlayerEndGamePhaseNotificationEvent;
 import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
 import com.forerunnergames.tools.net.annotations.RequiredForNetworkSerialization;
-import com.forerunnergames.tools.net.events.remote.origin.server.BroadcastNotificationEvent;
 
-public final class EndAttackPhaseEvent extends AbstractPlayerEvent implements BroadcastNotificationEvent
+public final class EndAttackPhaseEvent extends AbstractPlayerGamePhaseNotificationEvent
+        implements PlayerEndGamePhaseNotificationEvent
 {
   public EndAttackPhaseEvent (final PlayerPacket player)
   {
-    super (player);
+    super (player, GamePhase.ATTACK);
   }
 
   @RequiredForNetworkSerialization

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/EndFortifyPhaseEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/EndFortifyPhaseEvent.java
@@ -18,16 +18,18 @@
 
 package com.forerunnergames.peril.common.net.events.server.notify.broadcast;
 
-import com.forerunnergames.peril.common.net.events.server.defaults.AbstractPlayerEvent;
+import com.forerunnergames.peril.common.game.GamePhase;
+import com.forerunnergames.peril.common.net.events.server.defaults.AbstractPlayerGamePhaseNotificationEvent;
+import com.forerunnergames.peril.common.net.events.server.interfaces.PlayerEndGamePhaseNotificationEvent;
 import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
 import com.forerunnergames.tools.net.annotations.RequiredForNetworkSerialization;
-import com.forerunnergames.tools.net.events.remote.origin.server.BroadcastNotificationEvent;
 
-public final class EndFortifyPhaseEvent extends AbstractPlayerEvent implements BroadcastNotificationEvent
+public final class EndFortifyPhaseEvent extends AbstractPlayerGamePhaseNotificationEvent
+        implements PlayerEndGamePhaseNotificationEvent
 {
   public EndFortifyPhaseEvent (final PlayerPacket player)
   {
-    super (player);
+    super (player, GamePhase.FORTIFY);
   }
 
   @RequiredForNetworkSerialization

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/EndGameEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/EndGameEvent.java
@@ -17,13 +17,14 @@
 
 package com.forerunnergames.peril.common.net.events.server.notify.broadcast;
 
-import com.forerunnergames.tools.net.annotations.RequiredForNetworkSerialization;
-import com.forerunnergames.tools.net.events.remote.origin.server.BroadcastNotificationEvent;
+import com.forerunnergames.peril.common.game.GamePhase;
+import com.forerunnergames.peril.common.net.events.server.defaults.AbstractGamePhaseNotificationEvent;
+import com.forerunnergames.peril.common.net.events.server.interfaces.BeginGamePhaseNotificationEvent;
 
-public final class EndGameEvent implements BroadcastNotificationEvent
+public final class EndGameEvent extends AbstractGamePhaseNotificationEvent implements BeginGamePhaseNotificationEvent
 {
-  @RequiredForNetworkSerialization
   public EndGameEvent ()
   {
+    super (GamePhase.END);
   }
 }

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/EndInitialCountryAssignmentPhaseEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/EndInitialCountryAssignmentPhaseEvent.java
@@ -18,25 +18,30 @@
 
 package com.forerunnergames.peril.common.net.events.server.notify.broadcast;
 
+import com.forerunnergames.peril.common.game.GamePhase;
 import com.forerunnergames.peril.common.game.InitialCountryAssignment;
+import com.forerunnergames.peril.common.net.events.server.defaults.AbstractGamePhaseNotificationEvent;
+import com.forerunnergames.peril.common.net.events.server.interfaces.EndGamePhaseNotificationEvent;
 import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
 import com.forerunnergames.peril.common.net.packets.territory.CountryPacket;
 import com.forerunnergames.tools.common.Arguments;
 import com.forerunnergames.tools.common.Strings;
 import com.forerunnergames.tools.net.annotations.RequiredForNetworkSerialization;
-import com.forerunnergames.tools.net.events.remote.origin.server.BroadcastNotificationEvent;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-public final class PlayerCountryAssignmentCompleteEvent implements BroadcastNotificationEvent
+public final class EndInitialCountryAssignmentPhaseEvent extends AbstractGamePhaseNotificationEvent
+        implements EndGamePhaseNotificationEvent
 {
   private final InitialCountryAssignment assignmentMode;
   private final ImmutableMap <CountryPacket, PlayerPacket> countryToPlayerPackets;
 
-  public PlayerCountryAssignmentCompleteEvent (final InitialCountryAssignment assignmentMode,
-                                               final ImmutableMap <CountryPacket, PlayerPacket> countryToPlayerPackets)
+  public EndInitialCountryAssignmentPhaseEvent (final InitialCountryAssignment assignmentMode,
+                                                final ImmutableMap <CountryPacket, PlayerPacket> countryToPlayerPackets)
   {
+    super (GamePhase.INITIAL_COUNTRY_ASSIGNMENT);
+
     Arguments.checkIsNotNull (assignmentMode, "assignmentMode");
     Arguments.checkIsNotNull (countryToPlayerPackets, "countryToPlayerPackets");
     Arguments.checkHasNoNullKeysOrValues (countryToPlayerPackets, "countryToPlayerPackets");
@@ -77,12 +82,12 @@ public final class PlayerCountryAssignmentCompleteEvent implements BroadcastNoti
   @Override
   public String toString ()
   {
-    return Strings.format ("{}: AssignmentMode: {} | CountryToPlayerPackets: [{}]", getClass ().getSimpleName (),
+    return Strings.format ("{} | AssignmentMode: [{}] | CountryToPlayerPackets: [{}]", super.toString (),
                            assignmentMode, Strings.toString (countryToPlayerPackets));
   }
 
   @RequiredForNetworkSerialization
-  private PlayerCountryAssignmentCompleteEvent ()
+  private EndInitialCountryAssignmentPhaseEvent ()
   {
     assignmentMode = null;
     countryToPlayerPackets = null;

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/EndInitialReinforcementPhaseEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/EndInitialReinforcementPhaseEvent.java
@@ -18,21 +18,26 @@
 
 package com.forerunnergames.peril.common.net.events.server.notify.broadcast;
 
+import com.forerunnergames.peril.common.game.GamePhase;
+import com.forerunnergames.peril.common.net.events.server.defaults.AbstractGamePhaseNotificationEvent;
+import com.forerunnergames.peril.common.net.events.server.interfaces.EndGamePhaseNotificationEvent;
 import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
 import com.forerunnergames.peril.common.net.packets.territory.CountryPacket;
 import com.forerunnergames.tools.common.Arguments;
 import com.forerunnergames.tools.common.Strings;
 import com.forerunnergames.tools.net.annotations.RequiredForNetworkSerialization;
-import com.forerunnergames.tools.net.events.remote.origin.server.BroadcastNotificationEvent;
 
 import com.google.common.collect.ImmutableMap;
 
-public final class EndInitialReinforcementPhaseEvent implements BroadcastNotificationEvent
+public final class EndInitialReinforcementPhaseEvent extends AbstractGamePhaseNotificationEvent
+        implements EndGamePhaseNotificationEvent
 {
   private final ImmutableMap <CountryPacket, PlayerPacket> playMapView;
 
   public EndInitialReinforcementPhaseEvent (final ImmutableMap <CountryPacket, PlayerPacket> playMapView)
   {
+    super (GamePhase.INITIAL_REINFORCEMENT);
+
     Arguments.checkIsNotNull (playMapView, "playMapView");
 
     this.playMapView = playMapView;
@@ -46,7 +51,7 @@ public final class EndInitialReinforcementPhaseEvent implements BroadcastNotific
   @Override
   public String toString ()
   {
-    return Strings.format ("{}: PlayMapView: [{}]", getClass ().getSimpleName (), playMapView);
+    return Strings.format ("{} | PlayMapView: [{}]", super.toString (), playMapView);
   }
 
   @RequiredForNetworkSerialization

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/EndReinforcementPhaseEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/EndReinforcementPhaseEvent.java
@@ -18,23 +18,25 @@
 
 package com.forerunnergames.peril.common.net.events.server.notify.broadcast;
 
-import com.forerunnergames.peril.common.net.events.server.defaults.AbstractPlayerEvent;
+import com.forerunnergames.peril.common.game.GamePhase;
+import com.forerunnergames.peril.common.net.events.server.defaults.AbstractPlayerGamePhaseNotificationEvent;
+import com.forerunnergames.peril.common.net.events.server.interfaces.PlayerEndGamePhaseNotificationEvent;
 import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
 import com.forerunnergames.peril.common.net.packets.territory.CountryPacket;
 import com.forerunnergames.tools.common.Arguments;
 import com.forerunnergames.tools.common.Strings;
 import com.forerunnergames.tools.net.annotations.RequiredForNetworkSerialization;
-import com.forerunnergames.tools.net.events.remote.origin.server.BroadcastNotificationEvent;
 
 import com.google.common.collect.ImmutableSet;
 
-public final class EndReinforcementPhaseEvent extends AbstractPlayerEvent implements BroadcastNotificationEvent
+public final class EndReinforcementPhaseEvent extends AbstractPlayerGamePhaseNotificationEvent
+        implements PlayerEndGamePhaseNotificationEvent
 {
   private final ImmutableSet <CountryPacket> playerOwnedCountries;
 
   public EndReinforcementPhaseEvent (final PlayerPacket player, final ImmutableSet <CountryPacket> playerOwnedCountries)
   {
-    super (player);
+    super (player, GamePhase.REINFORCEMENT);
 
     Arguments.checkIsNotNull (playerOwnedCountries, "playerOwnedCountries");
 

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/SkipFortifyPhaseEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/SkipFortifyPhaseEvent.java
@@ -1,15 +1,17 @@
 package com.forerunnergames.peril.common.net.events.server.notify.broadcast;
 
-import com.forerunnergames.peril.common.net.events.server.defaults.AbstractPlayerEvent;
+import com.forerunnergames.peril.common.game.GamePhase;
+import com.forerunnergames.peril.common.net.events.server.defaults.AbstractPlayerGamePhaseNotificationEvent;
+import com.forerunnergames.peril.common.net.events.server.interfaces.PlayerSkipGamePhaseNotificationEvent;
 import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
 import com.forerunnergames.tools.net.annotations.RequiredForNetworkSerialization;
-import com.forerunnergames.tools.net.events.remote.origin.server.BroadcastNotificationEvent;
 
-public final class SkipFortifyPhaseEvent extends AbstractPlayerEvent implements BroadcastNotificationEvent
+public final class SkipFortifyPhaseEvent extends AbstractPlayerGamePhaseNotificationEvent
+        implements PlayerSkipGamePhaseNotificationEvent
 {
   public SkipFortifyPhaseEvent (final PlayerPacket player)
   {
-    super (player);
+    super (player, GamePhase.FORTIFY);
   }
 
   @RequiredForNetworkSerialization

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/SkipReinforcementPhaseEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/SkipReinforcementPhaseEvent.java
@@ -1,24 +1,26 @@
 package com.forerunnergames.peril.common.net.events.server.notify.broadcast;
 
-import com.forerunnergames.peril.common.net.events.server.defaults.AbstractPlayerEvent;
+import com.forerunnergames.peril.common.game.GamePhase;
+import com.forerunnergames.peril.common.net.events.server.defaults.AbstractPlayerGamePhaseNotificationEvent;
+import com.forerunnergames.peril.common.net.events.server.interfaces.PlayerSkipGamePhaseNotificationEvent;
 import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
 import com.forerunnergames.tools.common.Arguments;
 import com.forerunnergames.tools.common.Strings;
 import com.forerunnergames.tools.net.annotations.RequiredForNetworkSerialization;
-import com.forerunnergames.tools.net.events.remote.origin.server.BroadcastNotificationEvent;
 
-public class SkipReinforcementPhaseEvent extends AbstractPlayerEvent implements BroadcastNotificationEvent
+public class SkipReinforcementPhaseEvent extends AbstractPlayerGamePhaseNotificationEvent
+        implements PlayerSkipGamePhaseNotificationEvent
 {
+  private final Reason reason;
+
   public enum Reason
   {
     COUNTRY_ARMY_OVERFLOW
   }
 
-  private final Reason reason;
-
   public SkipReinforcementPhaseEvent (final PlayerPacket player, final Reason reason)
   {
-    super (player);
+    super (player, GamePhase.REINFORCEMENT);
 
     Arguments.checkIsNotNull (reason, "reason");
 

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/SuspendGameEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/SuspendGameEvent.java
@@ -17,11 +17,14 @@
 
 package com.forerunnergames.peril.common.net.events.server.notify.broadcast;
 
+import com.forerunnergames.peril.common.game.GamePhase;
+import com.forerunnergames.peril.common.net.events.server.defaults.AbstractGamePhaseNotificationEvent;
+import com.forerunnergames.peril.common.net.events.server.interfaces.BeginGamePhaseNotificationEvent;
 import com.forerunnergames.tools.common.Strings;
 import com.forerunnergames.tools.net.annotations.RequiredForNetworkSerialization;
-import com.forerunnergames.tools.net.events.remote.origin.server.BroadcastNotificationEvent;
 
-public final class SuspendGameEvent implements BroadcastNotificationEvent
+public final class SuspendGameEvent extends AbstractGamePhaseNotificationEvent
+        implements BeginGamePhaseNotificationEvent
 {
   private final Reason reason;
   private final long timeoutMillis;
@@ -39,6 +42,8 @@ public final class SuspendGameEvent implements BroadcastNotificationEvent
 
   public SuspendGameEvent (final Reason reason, final long timeoutMillis)
   {
+    super (GamePhase.SUSPENDED);
+
     this.reason = reason;
     this.timeoutMillis = timeoutMillis;
   }
@@ -61,7 +66,7 @@ public final class SuspendGameEvent implements BroadcastNotificationEvent
   @Override
   public String toString ()
   {
-    return Strings.format ("{}: Reason: [{}] | TimeoutMillis: [{}]", getClass ().getSimpleName (), reason,
+    return Strings.format ("{} | Reason: [{}] | TimeoutMillis: [{}]", super.toString (), reason,
                            hasTimeout () ? timeoutMillis : "None");
   }
 

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/direct/PlayerRestoreGameStateEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/direct/PlayerRestoreGameStateEvent.java
@@ -18,6 +18,8 @@
 package com.forerunnergames.peril.common.net.events.server.notify.direct;
 
 import com.forerunnergames.peril.common.game.GamePhase;
+import com.forerunnergames.peril.common.game.rules.GameRules;
+import com.forerunnergames.peril.common.net.GameServerConfiguration;
 import com.forerunnergames.peril.common.net.events.server.defaults.AbstractPlayerEvent;
 import com.forerunnergames.peril.common.net.events.server.interfaces.DirectPlayerNotificationEvent;
 import com.forerunnergames.peril.common.net.packets.card.CardSetPacket;
@@ -36,37 +38,46 @@ import java.util.Map;
 public final class PlayerRestoreGameStateEvent extends AbstractPlayerEvent implements DirectPlayerNotificationEvent
 {
   private final PlayerPacket currentPlayer;
-  private final GamePhase currentPhase;
-  private final int currentRound;
+  private final GamePhase currentGamePhase;
+  private final int currentGameRound;
   private final CardSetPacket cardsInHand;
   private final ImmutableSet <CardSetPacket> availableTradeIns;
   private final ImmutableMap <CountryPacket, PlayerPacket> countriesToPlayers;
+  private final GameServerConfiguration gameServerConfig;
 
   public PlayerRestoreGameStateEvent (final PlayerPacket selfPlayer,
                                       final PlayerPacket currentPlayer,
-                                      final GamePhase currentPhase,
-                                      final int currentRound,
+                                      final GamePhase currentGamePhase,
+                                      final int currentGameRound,
                                       final CardSetPacket cardsInHand,
                                       final ImmutableSet <CardSetPacket> availableTradeIns,
-                                      final ImmutableMap <CountryPacket, PlayerPacket> countriesToPlayers)
+                                      final ImmutableMap <CountryPacket, PlayerPacket> countriesToPlayers,
+                                      final GameServerConfiguration gameServerConfig)
   {
     super (selfPlayer);
 
     Arguments.checkIsNotNull (currentPlayer, "currentPlayer");
-    Arguments.checkIsNotNull (currentPhase, "currentPhase");
-    Arguments.checkIsNotNegative (currentRound, "currentRound");
+    Arguments.checkIsNotNull (currentGamePhase, "currentGamePhase");
+    Arguments.checkIsNotNegative (currentGameRound, "currentGameRound");
     Arguments.checkIsNotNull (cardsInHand, "cardsInHand");
     Arguments.checkIsNotNull (availableTradeIns, "availableTradeIns");
     Arguments.checkHasNoNullElements (availableTradeIns, "availableTradeIns");
     Arguments.checkIsNotNull (countriesToPlayers, "countriesToPlayers");
     Arguments.checkHasNoNullKeysOrValues (countriesToPlayers, "countriesToPlayers");
+    Arguments.checkIsNotNull (gameServerConfig, "gameServerConfig");
 
     this.currentPlayer = currentPlayer;
-    this.currentPhase = currentPhase;
-    this.currentRound = currentRound;
+    this.currentGamePhase = currentGamePhase;
+    this.currentGameRound = currentGameRound;
     this.cardsInHand = cardsInHand;
     this.availableTradeIns = availableTradeIns;
     this.countriesToPlayers = countriesToPlayers;
+    this.gameServerConfig = gameServerConfig;
+  }
+
+  public PlayerPacket getSelfPlayer ()
+  {
+    return getPerson ();
   }
 
   public PlayerPacket getCurrentPlayer ()
@@ -74,14 +85,14 @@ public final class PlayerRestoreGameStateEvent extends AbstractPlayerEvent imple
     return currentPlayer;
   }
 
-  public GamePhase getCurrentPhase ()
+  public GamePhase getCurrentGamePhase ()
   {
-    return currentPhase;
+    return currentGamePhase;
   }
 
-  public int getCurrentRound ()
+  public int getCurrentGameRound ()
   {
-    return currentRound;
+    return currentGameRound;
   }
 
   public CardSetPacket getCardsInHand ()
@@ -123,24 +134,35 @@ public final class PlayerRestoreGameStateEvent extends AbstractPlayerEvent imple
     return owner;
   }
 
+  public GameServerConfiguration getGameServerConfiguration ()
+  {
+    return gameServerConfig;
+  }
+
+  public GameRules getGameRules ()
+  {
+    return gameServerConfig.getGameRules ();
+  }
+
   @Override
   public String toString ()
   {
     return Strings.format (
                            "{} | CurrentPlayer: [{}] | CurrentPhase: [{}] | CurrentRound: [{}] | CardsInHand: [{}] | "
-                                   + "AvailableTradeIns: [{}] | CountriesToPlayers: [{}] ",
-                           super.toString (), currentPlayer, currentPhase, currentRound, cardsInHand, availableTradeIns,
-                           countriesToPlayers);
+                                   + "AvailableTradeIns: [{}] | CountriesToPlayers: [{}] | GameServerConfig: [{}]",
+                           super.toString (), currentPlayer, currentGamePhase, currentGameRound, cardsInHand,
+                           availableTradeIns, countriesToPlayers, gameServerConfig);
   }
 
   @RequiredForNetworkSerialization
   private PlayerRestoreGameStateEvent ()
   {
     currentPlayer = null;
-    currentPhase = GamePhase.UNKNOWN;
-    currentRound = 0;
+    currentGamePhase = null;
+    currentGameRound = 0;
     cardsInHand = null;
     availableTradeIns = null;
     countriesToPlayers = null;
+    gameServerConfig = null;
   }
 }

--- a/core/src/main/java/com/forerunnergames/peril/core/events/internal/player/SendGameStateRequestEvent.java
+++ b/core/src/main/java/com/forerunnergames/peril/core/events/internal/player/SendGameStateRequestEvent.java
@@ -1,20 +1,24 @@
 package com.forerunnergames.peril.core.events.internal.player;
 
+import com.forerunnergames.peril.common.net.GameServerConfiguration;
 import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
 import com.forerunnergames.peril.core.events.internal.defaults.AbstractInternalCommunicationEvent;
 import com.forerunnergames.peril.core.events.internal.interfaces.InternalRequestEvent;
 import com.forerunnergames.tools.common.Arguments;
 import com.forerunnergames.tools.common.Strings;
 
-public class SendGameStateRequestEvent extends AbstractInternalCommunicationEvent implements InternalRequestEvent
+public final class SendGameStateRequestEvent extends AbstractInternalCommunicationEvent implements InternalRequestEvent
 {
   private final PlayerPacket targetPlayer;
+  private final GameServerConfiguration gameServerConfig;
 
-  public SendGameStateRequestEvent (final PlayerPacket targetPlayer)
+  public SendGameStateRequestEvent (final PlayerPacket targetPlayer, final GameServerConfiguration gameServerConfig)
   {
     Arguments.checkIsNotNull (targetPlayer, "targetPlayer");
+    Arguments.checkIsNotNull (gameServerConfig, "gameServerConfig");
 
     this.targetPlayer = targetPlayer;
+    this.gameServerConfig = gameServerConfig;
   }
 
   public PlayerPacket getTargetPlayer ()
@@ -22,9 +26,15 @@ public class SendGameStateRequestEvent extends AbstractInternalCommunicationEven
     return targetPlayer;
   }
 
+  public GameServerConfiguration getGameServerConfiguration ()
+  {
+    return gameServerConfig;
+  }
+
   @Override
   public String toString ()
   {
-    return Strings.format ("{} | TargetPlayer: [{}]", super.toString (), targetPlayer);
+    return Strings.format ("{} | TargetPlayer: [{}] | GameServerConfig: [{}]", super.toString (), targetPlayer,
+                           gameServerConfig);
   }
 }

--- a/core/src/main/java/com/forerunnergames/peril/core/model/game/GameModel.java
+++ b/core/src/main/java/com/forerunnergames/peril/core/model/game/GameModel.java
@@ -268,15 +268,15 @@ public final class GameModel extends AbstractGamePhaseHandler
     final Id targetPlayerId = playerModel.idOf (targetPlayerName);
 
     final PlayerPacket currentPlayer = getCurrentPlayerPacket ();
-    final GamePhase currentPhsae = getCurrentGamePhase ();
+    final GamePhase currentPhase = getCurrentGamePhase ();
     final int currentRoundNumber = playerTurnModel.getRound ();
     final ImmutableMap <CountryPacket, PlayerPacket> countriesToPlayers = buildPlayMapViewFrom (playerModel,
                                                                                                 playMapModel);
     final CardSetPacket cardsInHand = CardPackets.fromCards (cardModel.getCardsInHand (targetPlayerId));
     final ImmutableSet <CardSetPacket> availableTradeIns = CardPackets
             .fromCardMatchSet (cardModel.computeMatchesFor (targetPlayerId));
-    publish (new PlayerRestoreGameStateEvent (event.getTargetPlayer (), currentPlayer, currentPhsae, currentRoundNumber,
-            cardsInHand, availableTradeIns, countriesToPlayers));
+    publish (new PlayerRestoreGameStateEvent (event.getTargetPlayer (), currentPlayer, currentPhase, currentRoundNumber,
+            cardsInHand, availableTradeIns, countriesToPlayers, event.getGameServerConfiguration ()));
     publish (new SendGameStateResponseEvent (ResponseCode.OK, event.getEventId ()));
   }
 

--- a/core/src/main/java/com/forerunnergames/peril/core/model/game/phase/AbstractGamePhaseHandler.java
+++ b/core/src/main/java/com/forerunnergames/peril/core/model/game/phase/AbstractGamePhaseHandler.java
@@ -287,7 +287,7 @@ public abstract class AbstractGamePhaseHandler implements GamePhaseHandler
   }
 
   /**
-   * Checks whether or not a player has won or lost the game in the current game state
+   * Checks whether or not a player has won or lost the game in the current game state.
    */
   protected GameStatus checkPlayerGameStatus (final Id playerId)
   {

--- a/core/src/main/java/com/forerunnergames/peril/core/model/game/phase/turn/DefaultAttackPhaseHandler.java
+++ b/core/src/main/java/com/forerunnergames/peril/core/model/game/phase/turn/DefaultAttackPhaseHandler.java
@@ -18,6 +18,7 @@ import com.forerunnergames.peril.common.net.events.server.denied.PlayerSelectAtt
 import com.forerunnergames.peril.common.net.events.server.inform.PlayerAttackCountryEvent;
 import com.forerunnergames.peril.common.net.events.server.inform.PlayerEndTurnAvailableEvent;
 import com.forerunnergames.peril.common.net.events.server.inform.PlayerSelectAttackVectorEvent;
+import com.forerunnergames.peril.common.net.events.server.interfaces.GamePhaseNotificationEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginAttackPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndAttackPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerAttackCountryWaitEvent;
@@ -85,8 +86,10 @@ public final class DefaultAttackPhaseHandler extends AbstractGamePhaseHandler im
   {
     final PlayerPacket currentPlayer = getCurrentPlayerPacket ();
     log.info ("Begin attack phase for player [{}].", currentPlayer);
-    changeGamePhaseTo (GamePhase.ATTACK);
-    publish (new BeginAttackPhaseEvent (currentPlayer));
+    final GamePhaseNotificationEvent event = new BeginAttackPhaseEvent (currentPlayer);
+
+    changeGamePhaseTo (event.getGamePhase ());
+    publish (event);
   }
 
   @StateExitAction

--- a/core/src/main/java/com/forerunnergames/peril/core/model/game/phase/turn/DefaultFortifyPhaseHandler.java
+++ b/core/src/main/java/com/forerunnergames/peril/core/model/game/phase/turn/DefaultFortifyPhaseHandler.java
@@ -1,6 +1,5 @@
 package com.forerunnergames.peril.core.model.game.phase.turn;
 
-import com.forerunnergames.peril.common.game.GamePhase;
 import com.forerunnergames.peril.common.net.events.client.request.inform.PlayerCancelFortifyRequestEvent;
 import com.forerunnergames.peril.common.net.events.client.request.inform.PlayerFortifyCountryRequestEvent;
 import com.forerunnergames.peril.common.net.events.client.request.inform.PlayerSelectFortifyVectorRequestEvent;
@@ -11,6 +10,7 @@ import com.forerunnergames.peril.common.net.events.server.denied.PlayerSelectFor
 import com.forerunnergames.peril.common.net.events.server.inform.PlayerEndTurnAvailableEvent;
 import com.forerunnergames.peril.common.net.events.server.inform.PlayerFortifyCountryEvent;
 import com.forerunnergames.peril.common.net.events.server.inform.PlayerSelectFortifyVectorEvent;
+import com.forerunnergames.peril.common.net.events.server.interfaces.GamePhaseNotificationEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginFortifyPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndFortifyPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.SkipFortifyPhaseEvent;
@@ -79,9 +79,10 @@ public final class DefaultFortifyPhaseHandler extends AbstractGamePhaseHandler i
 
     log.info ("Begin fortify phase for player [{}].", currentPlayer);
 
-    changeGamePhaseTo (GamePhase.FORTIFY);
+    final GamePhaseNotificationEvent event = new BeginFortifyPhaseEvent (currentPlayer);
 
-    publish (new BeginFortifyPhaseEvent (currentPlayer));
+    changeGamePhaseTo (event.getGamePhase ());
+    publish (event);
   }
 
   @Override

--- a/core/src/main/java/com/forerunnergames/peril/core/model/game/phase/turn/DefaultReinforcementPhaseHandler.java
+++ b/core/src/main/java/com/forerunnergames/peril/core/model/game/phase/turn/DefaultReinforcementPhaseHandler.java
@@ -54,7 +54,7 @@ public final class DefaultReinforcementPhaseHandler extends AbstractGamePhaseHan
     {
       publish (new SkipReinforcementPhaseEvent (getCurrentPlayerPacket (),
               SkipReinforcementPhaseEvent.Reason.COUNTRY_ARMY_OVERFLOW));
-      log.info ("No valid countries for reinforcment. Skipping phase...", getCurrentPlayerPacket ());
+      log.info ("No valid countries for reinforcement for player: [{}]. Skipping phase...", getCurrentPlayerPacket ());
       return;
     }
 

--- a/core/src/main/java/com/forerunnergames/peril/core/model/state/StateMachineEventHandler.java
+++ b/core/src/main/java/com/forerunnergames/peril/core/model/state/StateMachineEventHandler.java
@@ -39,7 +39,7 @@ import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndGa
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndInitialReinforcementPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndPlayerTurnEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndReinforcementPhaseEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.PlayerCountryAssignmentCompleteEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndInitialCountryAssignmentPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.ResumeGameEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.SkipFortifyPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.SkipPlayerTurnEvent;
@@ -245,13 +245,13 @@ public final class StateMachineEventHandler
   }
 
   @Handler
-  public void onEvent (final PlayerCountryAssignmentCompleteEvent event)
+  public void onEvent (final EndInitialCountryAssignmentPhaseEvent event)
   {
     Arguments.checkIsNotNull (event, "event");
 
     log.trace ("Received event {}", event);
 
-    context.onPlayerCountryAssignmentCompleteEvent (event);
+    context.onEndInitialCountryAssignmentPhaseEvent (event);
   }
 
   @Handler

--- a/core/src/main/res/GameStateMachine.fsmjava
+++ b/core/src/main/res/GameStateMachine.fsmjava
@@ -70,9 +70,9 @@
                 type="com.forerunnergames.peril.common.net.events.server.success.PlayerClaimCountryResponseSuccessEvent"
                 name="event"/>
       </event>
-      <event id="onPlayerCountryAssignmentCompleteEvent">
+      <event id="onEndInitialCountryAssignmentPhaseEvent">
         <parameter
-                type="com.forerunnergames.peril.common.net.events.server.notify.broadcast.PlayerCountryAssignmentCompleteEvent"
+                type="com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndInitialCountryAssignmentPhaseEvent"
                 name="event"/>
       </event>
       <event id="onEndInitialReinforcementPhaseEvent">
@@ -271,7 +271,7 @@
                 </state>
                 <state name="RandomlyAssignPlayerCountries">
                   <onEntry action="initialPhase.randomlyAssignPlayerCountries()"/>
-                  <transition event="onPlayerCountryAssignmentCompleteEvent" nextState="InitialReinforcementPhase"/>
+                  <transition event="onEndInitialCountryAssignmentPhaseEvent" nextState="InitialReinforcementPhase"/>
                 </state>
                 <state name="ManuallyAssignPlayerCountries">
                   <state name="WaitForPlayersToClaimInitialCountries">
@@ -280,7 +280,7 @@
                     <transition event="onPlayerClaimCountryResponseRequestEvent"
                                 condition="initialPhase.verifyPlayerClaimCountryResponseRequest(event)"
                                 nextState="WaitForPlayersToClaimInitialCountries"/>
-                    <transition event="onPlayerCountryAssignmentCompleteEvent" nextState="InitialReinforcementPhase"/>
+                    <transition event="onEndInitialCountryAssignmentPhaseEvent" nextState="InitialReinforcementPhase"/>
                     <transition event="onSkipPlayerTurnEvent"
                                 condition="gameModel.skipPlayerTurn(event)"
                                 nextState="WaitForPlayersToReinforceInitialCountries"/>

--- a/core/src/test/java/com/forerunnergames/peril/core/model/game/phase/AbstractGamePhaseHandlerTest.java
+++ b/core/src/test/java/com/forerunnergames/peril/core/model/game/phase/AbstractGamePhaseHandlerTest.java
@@ -17,7 +17,7 @@ import com.forerunnergames.peril.common.net.events.client.interfaces.PlayerRespo
 import com.forerunnergames.peril.common.net.events.client.request.HumanPlayerJoinGameRequestEvent;
 import com.forerunnergames.peril.common.net.events.server.denied.PlayerJoinGameDeniedEvent;
 import com.forerunnergames.peril.common.net.events.server.interfaces.PlayerInputRequestEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.PlayerCountryAssignmentCompleteEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndInitialCountryAssignmentPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerJoinGameSuccessEvent;
 import com.forerunnergames.peril.common.net.packets.territory.CountryPacket;
 import com.forerunnergames.peril.core.events.EventRegistry;
@@ -184,8 +184,8 @@ public abstract class AbstractGamePhaseHandlerTest
     for (final Id country : countryGraphModel.getCountryIds ())
     {
       assertTrue (countryOwnerModel.isCountryOwned (country));
-      final PlayerCountryAssignmentCompleteEvent event = eventHandler
-              .lastEventOfType (PlayerCountryAssignmentCompleteEvent.class);
+      final EndInitialCountryAssignmentPhaseEvent event = eventHandler
+              .lastEventOfType (EndInitialCountryAssignmentPhaseEvent.class);
       final CountryPacket countryPacket = countryGraphModel.countryPacketWith (country);
       final Id player = countryOwnerModel.ownerOf (country);
       assertEquals (playerModel.playerPacketWith (player), event.getOwner (countryPacket));

--- a/core/src/test/java/com/forerunnergames/peril/core/model/game/phase/init/InitialPhaseHandlerTest.java
+++ b/core/src/test/java/com/forerunnergames/peril/core/model/game/phase/init/InitialPhaseHandlerTest.java
@@ -16,10 +16,10 @@ import com.forerunnergames.peril.common.net.events.server.inform.PlayerReinforce
 import com.forerunnergames.peril.common.net.events.server.interfaces.PlayerArmiesChangedEvent;
 import com.forerunnergames.peril.common.net.events.server.interfaces.PlayerTurnOrderChangedEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.ActivePlayerChangedEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginPlayerCountryAssignmentEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginInitialCountryAssignmentPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.DeterminePlayerTurnOrderCompleteEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.DistributeInitialArmiesCompleteEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.PlayerCountryAssignmentCompleteEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndInitialCountryAssignmentPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.SkipPlayerTurnEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerReinforceCountryWaitEvent;
 import com.forerunnergames.peril.common.net.events.server.request.PlayerClaimCountryRequestEvent;
@@ -119,7 +119,7 @@ public class InitialPhaseHandlerTest extends AbstractGamePhaseHandlerTest
   }
 
   @Test
-  public void testWaitForCountryAssignmentToBeginRandom ()
+  public void testWaitForInitialCountryAssignmentToBeginRandom ()
   {
     gameRules = ClassicGameRules.builder ().maxHumanPlayers ().totalCountryCount (defaultTestCountryCount)
             .initialCountryAssignment (InitialCountryAssignment.RANDOM).build ();
@@ -132,15 +132,15 @@ public class InitialPhaseHandlerTest extends AbstractGamePhaseHandlerTest
 
     initialPhase.waitForCountryAssignmentToBegin ();
 
-    assertGamePhaseIs (GamePhase.INITIAL);
+    assertGamePhaseIs (GamePhase.INITIAL_COUNTRY_ASSIGNMENT);
 
-    assertTrue (eventHandler.wasFiredExactlyOnce (BeginPlayerCountryAssignmentEvent.class));
+    assertTrue (eventHandler.wasFiredExactlyOnce (BeginInitialCountryAssignmentPhaseEvent.class));
     assertEquals (InitialCountryAssignment.RANDOM,
-                  eventHandler.lastEventOfType (BeginPlayerCountryAssignmentEvent.class).getAssignmentMode ());
+                  eventHandler.lastEventOfType (BeginInitialCountryAssignmentPhaseEvent.class).getAssignmentMode ());
   }
 
   @Test
-  public void testWaitForCountryAssignmentToBeginManual ()
+  public void testWaitForInitialCountryAssignmentToBeginManual ()
   {
     gameRules = ClassicGameRules.builder ().maxHumanPlayers ().totalCountryCount (defaultTestCountryCount)
             .initialCountryAssignment (InitialCountryAssignment.MANUAL).build ();
@@ -154,11 +154,11 @@ public class InitialPhaseHandlerTest extends AbstractGamePhaseHandlerTest
 
     initialPhase.waitForCountryAssignmentToBegin ();
 
-    assertGamePhaseIs (GamePhase.MANUAL_COUNTRY_ASSIGNMENT);
+    assertGamePhaseIs (GamePhase.INITIAL_COUNTRY_ASSIGNMENT);
 
-    assertTrue (eventHandler.wasFiredExactlyOnce (BeginPlayerCountryAssignmentEvent.class));
+    assertTrue (eventHandler.wasFiredExactlyOnce (BeginInitialCountryAssignmentPhaseEvent.class));
     assertEquals (InitialCountryAssignment.MANUAL,
-                  eventHandler.lastEventOfType (BeginPlayerCountryAssignmentEvent.class).getAssignmentMode ());
+                  eventHandler.lastEventOfType (BeginInitialCountryAssignmentPhaseEvent.class).getAssignmentMode ());
   }
 
   @Test
@@ -174,7 +174,7 @@ public class InitialPhaseHandlerTest extends AbstractGamePhaseHandlerTest
     initialPhase.randomlyAssignPlayerCountries ();
 
     assertFalse (countryOwnerModel.hasAnyUnownedCountries ());
-    assertTrue (eventHandler.wasFiredExactlyOnce (PlayerCountryAssignmentCompleteEvent.class));
+    assertTrue (eventHandler.wasFiredExactlyOnce (EndInitialCountryAssignmentPhaseEvent.class));
     assertTrue (eventHandler.wasFiredExactlyNTimes (PlayerArmiesChangedEvent.class, playerModel.getPlayerCount ()));
     assertGamePhaseIs (GamePhase.INITIAL);
   }
@@ -203,7 +203,7 @@ public class InitialPhaseHandlerTest extends AbstractGamePhaseHandlerTest
     initialPhase.randomlyAssignPlayerCountries ();
 
     assertFalse (countryOwnerModel.hasAnyUnownedCountries ());
-    assertTrue (eventHandler.wasFiredExactlyOnce (PlayerCountryAssignmentCompleteEvent.class));
+    assertTrue (eventHandler.wasFiredExactlyOnce (EndInitialCountryAssignmentPhaseEvent.class));
     verifyPlayerCountryAssignmentCompleteEvent ();
     assertTrue (eventHandler.wasFiredExactlyNTimes (PlayerArmiesChangedEvent.class, playerModel.getPlayerCount ()));
     assertGamePhaseIs (GamePhase.INITIAL);
@@ -227,7 +227,7 @@ public class InitialPhaseHandlerTest extends AbstractGamePhaseHandlerTest
     initialPhase.randomlyAssignPlayerCountries ();
 
     assertTrue (countryOwnerModel.allCountriesAreOwned ());
-    assertTrue (eventHandler.wasFiredExactlyOnce (PlayerCountryAssignmentCompleteEvent.class));
+    assertTrue (eventHandler.wasFiredExactlyOnce (EndInitialCountryAssignmentPhaseEvent.class));
     verifyPlayerCountryAssignmentCompleteEvent ();
     assertTrue (eventHandler.wasFiredExactlyNTimes (PlayerArmiesChangedEvent.class, playerModel.getPlayerCount ()));
     assertGamePhaseIs (GamePhase.INITIAL);
@@ -259,7 +259,7 @@ public class InitialPhaseHandlerTest extends AbstractGamePhaseHandlerTest
 
     assertTrue (eventHandler.wasFiredExactlyOnce (PlayerClaimCountryRequestEvent.class));
     assertTrue (eventHandler.wasFiredExactlyOnce (ActivePlayerChangedEvent.class));
-    assertTrue (eventHandler.wasNeverFired (PlayerCountryAssignmentCompleteEvent.class));
+    assertTrue (eventHandler.wasNeverFired (EndInitialCountryAssignmentPhaseEvent.class));
 
     final PlayerPacket expectedPlayer = playerModel.playerPacketWith (PlayerTurnOrder.FIRST);
     assertTrue (eventHandler.lastEventOfType (PlayerClaimCountryRequestEvent.class).getPerson ().is (expectedPlayer));
@@ -278,7 +278,7 @@ public class InitialPhaseHandlerTest extends AbstractGamePhaseHandlerTest
     assertTrue (eventHandler.wasFiredExactlyOnce (SkipPlayerTurnEvent.class));
     assertTrue (eventHandler.wasNeverFired (PlayerClaimCountryRequestEvent.class));
     assertTrue (eventHandler.wasNeverFired (ActivePlayerChangedEvent.class));
-    assertTrue (eventHandler.wasNeverFired (PlayerCountryAssignmentCompleteEvent.class));
+    assertTrue (eventHandler.wasNeverFired (EndInitialCountryAssignmentPhaseEvent.class));
 
     final PlayerPacket expectedPlayer = playerModel.playerPacketWith (PlayerTurnOrder.FIRST);
     assertTrue (eventHandler.lastEvent (SkipPlayerTurnEvent.class).getPerson ().is (expectedPlayer));
@@ -301,7 +301,7 @@ public class InitialPhaseHandlerTest extends AbstractGamePhaseHandlerTest
 
     assertTrue (eventHandler.wasNeverFired (PlayerClaimCountryRequestEvent.class));
     assertTrue (eventHandler.wasNeverFired (ActivePlayerChangedEvent.class));
-    assertTrue (eventHandler.wasFiredExactlyOnce (PlayerCountryAssignmentCompleteEvent.class));
+    assertTrue (eventHandler.wasFiredExactlyOnce (EndInitialCountryAssignmentPhaseEvent.class));
 
     verifyPlayerCountryAssignmentCompleteEvent ();
   }
@@ -322,7 +322,7 @@ public class InitialPhaseHandlerTest extends AbstractGamePhaseHandlerTest
     initialPhase.verifyPlayerClaimCountryResponseRequest (responseRequest);
 
     assertTrue (eventHandler.wasFiredExactlyOnce (PlayerClaimCountryResponseSuccessEvent.class));
-    assertTrue (eventHandler.wasNeverFired (PlayerCountryAssignmentCompleteEvent.class));
+    assertTrue (eventHandler.wasNeverFired (EndInitialCountryAssignmentPhaseEvent.class));
     assertTrue (eventHandler.wasFiredExactlyOnce (PlayerArmiesChangedEvent.class));
   }
 
@@ -340,7 +340,7 @@ public class InitialPhaseHandlerTest extends AbstractGamePhaseHandlerTest
 
     assertTrue (eventHandler.wasFiredExactlyOnce (PlayerClaimCountryResponseDeniedEvent.class));
     assertTrue (eventHandler.wasNeverFired (PlayerClaimCountryResponseSuccessEvent.class));
-    assertTrue (eventHandler.wasNeverFired (PlayerCountryAssignmentCompleteEvent.class));
+    assertTrue (eventHandler.wasNeverFired (EndInitialCountryAssignmentPhaseEvent.class));
     assertTrue (eventHandler.wasNeverFired (PlayerArmiesChangedEvent.class));
   }
 

--- a/integration/src/integration/java/com/forerunnergames/peril/integration/core/func/init/InitialGamePhaseController.java
+++ b/integration/src/integration/java/com/forerunnergames/peril/integration/core/func/init/InitialGamePhaseController.java
@@ -28,8 +28,8 @@ import com.forerunnergames.peril.common.net.events.server.inform.PlayerReinforce
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginInitialReinforcementPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.DeterminePlayerTurnOrderCompleteEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.DistributeInitialArmiesCompleteEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndInitialCountryAssignmentPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndInitialReinforcementPhaseEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.PlayerCountryAssignmentCompleteEvent;
 import com.forerunnergames.peril.common.net.events.server.success.JoinGameServerSuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerJoinGameSuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerReinforceCountrySuccessEvent;
@@ -168,17 +168,17 @@ public final class InitialGamePhaseController implements TestPhaseController
   {
     final TestClientPool clientPool = session.getTestClientPool ();
     final AtomicInteger verifyCount = new AtomicInteger ();
-    final ClientEventCallback <PlayerCountryAssignmentCompleteEvent> callback = new ClientEventCallback <PlayerCountryAssignmentCompleteEvent> ()
+    final ClientEventCallback <EndInitialCountryAssignmentPhaseEvent> callback = new ClientEventCallback <EndInitialCountryAssignmentPhaseEvent> ()
     {
       @Override
-      public void onEventReceived (final Optional <PlayerCountryAssignmentCompleteEvent> eventWrapper,
+      public void onEventReceived (final Optional <EndInitialCountryAssignmentPhaseEvent> eventWrapper,
                                    final TestClient client)
       {
         Arguments.checkIsNotNull (eventWrapper, "eventWrapper");
         Arguments.checkIsNotNull (client, "client");
 
         if (!eventWrapper.isPresent ()) return;
-        final PlayerCountryAssignmentCompleteEvent event = eventWrapper.get ();
+        final EndInitialCountryAssignmentPhaseEvent event = eventWrapper.get ();
         final ImmutableSet <PlayerPacket> players = event.getPlayers ();
         if (players.contains (client.getPlayer ())) verifyCount.incrementAndGet ();
         final ImmutableSet.Builder <CountryPacket> playerCountries = ImmutableSet.builder ();
@@ -190,7 +190,7 @@ public final class InitialGamePhaseController implements TestPhaseController
       }
     };
     final ImmutableSet <TestClient> failed = clientPool
-            .waitForAllClientsToReceive (PlayerCountryAssignmentCompleteEvent.class, callback);
+            .waitForAllClientsToReceive (EndInitialCountryAssignmentPhaseEvent.class, callback);
     return new WaitForCommunicationActionResult (failed, verifyCount.get ());
   }
 

--- a/server/src/main/java/com/forerunnergames/peril/server/communicators/CoreCommunicator.java
+++ b/server/src/main/java/com/forerunnergames/peril/server/communicators/CoreCommunicator.java
@@ -18,12 +18,13 @@
 
 package com.forerunnergames.peril.server.communicators;
 
+import com.forerunnergames.peril.common.net.GameServerConfiguration;
 import com.forerunnergames.peril.common.net.events.server.interfaces.PlayerInputEvent;
 import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
 
 public interface CoreCommunicator
 {
-  void requestSendGameStateTo (PlayerPacket player);
+  void requestSendGameStateTo (final PlayerPacket player, final GameServerConfiguration config);
 
-  void notifyInputEventTimedOut (PlayerInputEvent inputEvent);
+  void notifyInputEventTimedOut (final PlayerInputEvent inputEvent);
 }

--- a/server/src/main/java/com/forerunnergames/peril/server/communicators/DefaultCoreCommunicator.java
+++ b/server/src/main/java/com/forerunnergames/peril/server/communicators/DefaultCoreCommunicator.java
@@ -18,6 +18,7 @@
 
 package com.forerunnergames.peril.server.communicators;
 
+import com.forerunnergames.peril.common.net.GameServerConfiguration;
 import com.forerunnergames.peril.common.net.events.server.interfaces.PlayerInputEvent;
 import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
 import com.forerunnergames.peril.core.events.internal.interfaces.InternalRequestEvent;
@@ -52,9 +53,12 @@ public class DefaultCoreCommunicator implements CoreCommunicator
   }
 
   @Override
-  public void requestSendGameStateTo (final PlayerPacket player)
+  public void requestSendGameStateTo (final PlayerPacket player, final GameServerConfiguration config)
   {
-    final SendGameStateRequestEvent requestEvent = new SendGameStateRequestEvent (player);
+    Arguments.checkIsNotNull (player, "player");
+    Arguments.checkIsNotNull (config, "config");
+
+    final SendGameStateRequestEvent requestEvent = new SendGameStateRequestEvent (player, config);
     eventBus.publish (requestEvent);
 
     final Optional <InternalResponseEvent> responseEvent = getResponseFor (requestEvent);

--- a/server/src/main/java/com/forerunnergames/peril/server/controllers/MultiplayerController.java
+++ b/server/src/main/java/com/forerunnergames/peril/server/controllers/MultiplayerController.java
@@ -1176,7 +1176,7 @@ public final class MultiplayerController extends ControllerAdapter
     publish (successEvent);
 
     // send current game state to player
-    coreCommunicator.requestSendGameStateTo (updatedPlayer);
+    coreCommunicator.requestSendGameStateTo (updatedPlayer, gameServerConfig);
 
     if (!eventCache.hasPendingEvents (updatedPlayer)) return;
 


### PR DESCRIPTION
NOTE 1: The primary goal of this commit is to restore the client's game phase
handlers after reconnecting to the game, although there are many other related
fixes & improvements, as well. Most of the changes are the refactorings
required to support the primary goal.

NOTE 2: The primary goal of this commit is currently thwarted by
https://forerunnergames.atlassian.net/browse/PERIL-896.

Client:

- Send PlayerQuitGameRequestEvent as a courtesty goodbye to the server when
  quitting a game from play screen or menu-to-play loading screen.

- Handle rejoin game errors on menu-to-play loading screen.

- Handle begin/end game phase events polymorphically to reduce play screen
  phase handling code.

- Make GamePhaseHandler's able to be polymorphically activated/deactivated
  based on the specified current game phase (in addition to the specified
  current player), which is extremely useful for handling
  PlayerRestoreGameStateEvent, where the alternative is to use a giant switch
  statement for the current game phase.

- Print status messages on play screen about disconnects / reconnects.

- Improve dialog titles & messages for disconnect / reconnect / suspend /
  pause.

- Fix bug whereby game phase handlers are not reset on play screen hide.

- Fix bug whereby attack & defend dialogs are not removed on play screen hide.
  Attack & defend dialogs and battle phase handlers are dynamically created
  when joining (or rejoining) a new game, since they require a GameRules
  instance.

Common:

- BUGFIX: Don't make BeginInitialReinforcementPhase a PlayerEvent taking the
  current player. This doesn't really make sense because initial reinforcement
  phase isn't specific to one player. Passing in the current player to said
  event makes it appear as if said event is specific to said player's turn,
  when it is not. Removing this allows it to NOT implement
  PlayerBeginGamePhaseNotificationEvent, which is ONLY to be used for a game
  phase specific to a single player, and instead allows it to simply implement
  BeginGamePhaseNotificationEvent, which is used for game phases that are not
  specific to a single player, such as initial reinforcement phase. This also
  correctly mirrors EndInitialReinforcementPhaseEvent, which ALREADY doesn't
  take the current player.

- Formalize begin/end/skip game phase events:

  - Refactor event system to include GamePhaseNotificationEvent interface,
    which are extended by the following interfaces:
    BeginGamePhaseNotificationEvent, EndGamePhaseNotificationEvent, &
    SkipGamePhaseNotificationEvent. All of the above are
    BroadcastNotificationEvent's. (There are also some abstract base classes to
    prevent myriad duplication).

  - Make all game-phase-related events implement one of the above interfaces,
    including non-intuitive ones such as [Begin|End]GameEvent &
    [Suspend|Resume]GameEvent. (Those extra ones are included because they have
    GamePhase enum analogues).

  - Phase-ify initial country assignment:

    - Rename [Begin]PlayerCountryAssignmentEvent[Complete] to
      [Begin|End]InitialCountryAssignmentPhaseEvent, so they can implement
      [Begin|End]GamePhaseNotificationEvent, so that the client can display the
      correct game phase during initial country assignment, whether random or
      manual. (Random country assignment will eventually be slowed down on the
      client so that players can see what's going on, and actually see the phase
      name in the intel box.)

    - Note: The speed at which the server can complete a game phase is not
      justification for not sending out begin/end events about it, as explained
      above because the client many times will need to slow it down to the
      realm of human perception & entertainment.

    - GamePhase: Remove MANUAL_COUNTRY_ASSIGNMENT & add INITIAL_COUNTRY_ASSIGNMENT,
      to match [Begin|End]PlayerCountryAssignmentEvent, which are mode-agnostic and
      so can't be passed a more specific game phase, without significantly
      reworking initial country assignment phase.

- PlayerRestoreGameStateEvent:

  - Make it take a GameConfiguration. This information is required to properly
    update everything on the client's play screen. Provide a getter for it as
    well.

  - Add #getGameRules convenience method since GameRules is required by the
    client's battle dialogs.

Core:

- GameModel: Fix publishing of PlayerRestoreGameStateEvent because it now
  requires a GameConfiguration.

  - Pass GameConfiguration into GameModelConfiguration. Require it in place of
    GameRules, since GameConfiguration contains GameRules.

- Phase-ify initial country assignment:

  - Set game phase to initial country assignment for every country assignment
    mode, not just manual only. This allows the new game phase event system to
    not be broken for random country assignment. Not to mention other game phases
    may be randomized in the future (such as initial reinforcement, see
    PERIL-698), so avoid creating special cases.

  - InitialGamePhaseHandlerTest: Fix initial country assignment tests to assert
    game phase is initial country assignment for both random & manual assignment
    modes.

Other:

- Rename DisconnectFromServerEvent to DisconnectFromServerDebugEvent to make it
  clear that it's only for debugging purposes and should be removed in
  production code (in addition to the TODO messages already present).

- PlayerRestoreGameStateEvent:

  - Add #getSelfPlayer convenience method to help eliminate confusion regarding
    the inherited #getPerson.

  - Rename #getCurrentPhase & #getCurrentRound to #getCurrentGamePhase &
    #getCurrentGameRound for better API alignment in client.

  - Set currentPhase to null in serialization constructor to avoid confusion
    and adhere to project standards, instead of GamePhase#UNKNOWN. Only
    primitives should have their default, non-null value.

- Add #shutDown convenience method to client::GamePhaseHandler, which is a
  combination of #deactivate & #reset.

- Make field final in ClassicModePlayScreen#getDenialMessage.

- DefaultInitialReinforcementPhaseHandler: Fix broken log message.

- AbstractGamePhaseHandler: Add period to end of javadoc sentence.

- GameModel: Fix spelling error in #onEvent (final SendGameStateRequestEvent event).

JIRA:

PERIL-861 #Done #time 8h