### PR TITLE
Fix player restore game state current game phase.

### DIFF
--- a/ai/src/main/java/com/forerunnergames/peril/ai/processors/ChatProcessor.java
+++ b/ai/src/main/java/com/forerunnergames/peril/ai/processors/ChatProcessor.java
@@ -19,18 +19,18 @@ package com.forerunnergames.peril.ai.processors;
 
 import com.forerunnergames.peril.common.net.GameServerConfiguration;
 import com.forerunnergames.peril.common.net.events.client.request.ChatMessageRequestEvent;
-import com.forerunnergames.peril.common.net.events.server.denied.PlayerEndTurnDeniedEvent;
 import com.forerunnergames.peril.common.net.events.server.denied.PlayerCancelFortifyDeniedEvent;
 import com.forerunnergames.peril.common.net.events.server.denied.PlayerClaimCountryResponseDeniedEvent;
 import com.forerunnergames.peril.common.net.events.server.denied.PlayerDefendCountryResponseDeniedEvent;
+import com.forerunnergames.peril.common.net.events.server.denied.PlayerEndTurnDeniedEvent;
 import com.forerunnergames.peril.common.net.events.server.denied.PlayerOccupyCountryResponseDeniedEvent;
 import com.forerunnergames.peril.common.net.events.server.denied.PlayerReinforceCountryDeniedEvent;
+import com.forerunnergames.peril.common.net.events.server.inform.PlayerAttackCountryEvent;
+import com.forerunnergames.peril.common.net.events.server.inform.PlayerCardTradeInAvailableEvent;
+import com.forerunnergames.peril.common.net.events.server.inform.PlayerFortifyCountryEvent;
+import com.forerunnergames.peril.common.net.events.server.inform.PlayerReinforceCountryEvent;
 import com.forerunnergames.peril.common.net.events.server.inform.PlayerSelectAttackVectorEvent;
 import com.forerunnergames.peril.common.net.events.server.inform.PlayerSelectFortifyVectorEvent;
-import com.forerunnergames.peril.common.net.events.server.inform.PlayerReinforceCountryEvent;
-import com.forerunnergames.peril.common.net.events.server.inform.PlayerCardTradeInAvailableEvent;
-import com.forerunnergames.peril.common.net.events.server.inform.PlayerAttackCountryEvent;
-import com.forerunnergames.peril.common.net.events.server.inform.PlayerFortifyCountryEvent;
 import com.forerunnergames.peril.common.net.events.server.interfaces.CountryOwnerChangedEvent;
 import com.forerunnergames.peril.common.net.events.server.interfaces.PlayerArmiesChangedEvent;
 import com.forerunnergames.peril.common.net.events.server.interfaces.PlayerEvent;
@@ -52,36 +52,36 @@ import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndIn
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndPlayerTurnEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndReinforcementPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndRoundEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.GameResumedEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.GameSuspendedEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.PlayerDisconnectEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.PlayerLoseGameEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.PlayerWinGameEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.ResumeGameEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.SkipFortifyPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.SkipPlayerTurnEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.SuspendGameEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerSelectAttackVectorWaitEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerSelectFortifyVectorWaitEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerReinforceCountryWaitEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerAttackCountryWaitEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerClaimCountryWaitEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerDefendCountryWaitEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerAttackCountryWaitEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerFortifyCountryWaitEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerOccupyCountryWaitEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerReinforceCountryWaitEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerSelectAttackVectorWaitEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerSelectFortifyVectorWaitEvent;
 import com.forerunnergames.peril.common.net.events.server.request.PlayerClaimCountryRequestEvent;
 import com.forerunnergames.peril.common.net.events.server.request.PlayerDefendCountryRequestEvent;
 import com.forerunnergames.peril.common.net.events.server.request.PlayerOccupyCountryRequestEvent;
 import com.forerunnergames.peril.common.net.events.server.success.ChatMessageSuccessEvent;
-import com.forerunnergames.peril.common.net.events.server.success.PlayerEndTurnSuccessEvent;
+import com.forerunnergames.peril.common.net.events.server.success.PlayerAttackCountrySuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerCancelFortifySuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerClaimCountryResponseSuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerDefendCountryResponseSuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerEndAttackPhaseSuccessEvent;
+import com.forerunnergames.peril.common.net.events.server.success.PlayerEndTurnSuccessEvent;
+import com.forerunnergames.peril.common.net.events.server.success.PlayerFortifyCountrySuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerJoinGameSuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerOccupyCountryResponseSuccessEvent;
-import com.forerunnergames.peril.common.net.events.server.success.PlayerAttackCountrySuccessEvent;
-import com.forerunnergames.peril.common.net.events.server.success.PlayerFortifyCountrySuccessEvent;
-import com.forerunnergames.peril.common.net.events.server.success.PlayerRetreatSuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerReinforceCountrySuccessEvent;
+import com.forerunnergames.peril.common.net.events.server.success.PlayerRetreatSuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerSelectAttackVectorSuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerTradeInCardsResponseSuccessEvent;
 import com.forerunnergames.peril.common.net.messages.DefaultChatMessage;
@@ -589,7 +589,7 @@ public final class ChatProcessor extends AbstractAiProcessor
   }
 
   @Handler
-  void onEvent (final SuspendGameEvent event)
+  void onEvent (final GameSuspendedEvent event)
   {
     Arguments.checkIsNotNull (event, "event");
 
@@ -597,7 +597,7 @@ public final class ChatProcessor extends AbstractAiProcessor
   }
 
   @Handler
-  void onEvent (final ResumeGameEvent event)
+  void onEvent (final GameResumedEvent event)
   {
     Arguments.checkIsNotNull (event, "event");
 

--- a/ai/src/main/java/com/forerunnergames/peril/ai/processors/GameLogicProcessor.java
+++ b/ai/src/main/java/com/forerunnergames/peril/ai/processors/GameLogicProcessor.java
@@ -19,31 +19,31 @@ package com.forerunnergames.peril.ai.processors;
 
 import com.forerunnergames.peril.common.game.DieRange;
 import com.forerunnergames.peril.common.net.GameServerConfiguration;
+import com.forerunnergames.peril.common.net.events.client.request.inform.PlayerAttackCountryRequestEvent;
 import com.forerunnergames.peril.common.net.events.client.request.inform.PlayerCancelFortifyRequestEvent;
 import com.forerunnergames.peril.common.net.events.client.request.inform.PlayerEndAttackPhaseRequestEvent;
 import com.forerunnergames.peril.common.net.events.client.request.inform.PlayerEndTurnRequestEvent;
-import com.forerunnergames.peril.common.net.events.client.request.inform.PlayerAttackCountryRequestEvent;
 import com.forerunnergames.peril.common.net.events.client.request.inform.PlayerFortifyCountryRequestEvent;
-import com.forerunnergames.peril.common.net.events.client.request.inform.PlayerRetreatRequestEvent;
 import com.forerunnergames.peril.common.net.events.client.request.inform.PlayerReinforceCountryRequestEvent;
+import com.forerunnergames.peril.common.net.events.client.request.inform.PlayerRetreatRequestEvent;
 import com.forerunnergames.peril.common.net.events.client.request.inform.PlayerSelectAttackVectorRequestEvent;
 import com.forerunnergames.peril.common.net.events.client.request.inform.PlayerSelectFortifyVectorRequestEvent;
 import com.forerunnergames.peril.common.net.events.client.request.inform.PlayerTradeInCardsRequestEvent;
 import com.forerunnergames.peril.common.net.events.client.request.response.PlayerClaimCountryResponseRequestEvent;
 import com.forerunnergames.peril.common.net.events.client.request.response.PlayerDefendCountryResponseRequestEvent;
 import com.forerunnergames.peril.common.net.events.client.request.response.PlayerOccupyCountryResponseRequestEvent;
-import com.forerunnergames.peril.common.net.events.server.denied.PlayerEndTurnDeniedEvent;
 import com.forerunnergames.peril.common.net.events.server.denied.PlayerCancelFortifyDeniedEvent;
 import com.forerunnergames.peril.common.net.events.server.denied.PlayerClaimCountryResponseDeniedEvent;
 import com.forerunnergames.peril.common.net.events.server.denied.PlayerDefendCountryResponseDeniedEvent;
+import com.forerunnergames.peril.common.net.events.server.denied.PlayerEndTurnDeniedEvent;
 import com.forerunnergames.peril.common.net.events.server.denied.PlayerOccupyCountryResponseDeniedEvent;
 import com.forerunnergames.peril.common.net.events.server.denied.PlayerReinforceCountryDeniedEvent;
+import com.forerunnergames.peril.common.net.events.server.inform.PlayerAttackCountryEvent;
+import com.forerunnergames.peril.common.net.events.server.inform.PlayerCardTradeInAvailableEvent;
+import com.forerunnergames.peril.common.net.events.server.inform.PlayerFortifyCountryEvent;
+import com.forerunnergames.peril.common.net.events.server.inform.PlayerReinforceCountryEvent;
 import com.forerunnergames.peril.common.net.events.server.inform.PlayerSelectAttackVectorEvent;
 import com.forerunnergames.peril.common.net.events.server.inform.PlayerSelectFortifyVectorEvent;
-import com.forerunnergames.peril.common.net.events.server.inform.PlayerReinforceCountryEvent;
-import com.forerunnergames.peril.common.net.events.server.inform.PlayerCardTradeInAvailableEvent;
-import com.forerunnergames.peril.common.net.events.server.inform.PlayerAttackCountryEvent;
-import com.forerunnergames.peril.common.net.events.server.inform.PlayerFortifyCountryEvent;
 import com.forerunnergames.peril.common.net.events.server.interfaces.CountryOwnerChangedEvent;
 import com.forerunnergames.peril.common.net.events.server.interfaces.PlayerArmiesChangedEvent;
 import com.forerunnergames.peril.common.net.events.server.interfaces.PlayerTurnOrderChangedEvent;
@@ -64,36 +64,36 @@ import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndIn
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndPlayerTurnEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndReinforcementPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndRoundEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.GameResumedEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.GameSuspendedEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.PlayerDisconnectEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.PlayerLoseGameEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.PlayerWinGameEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.ResumeGameEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.SkipFortifyPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.SkipPlayerTurnEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.SuspendGameEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerSelectAttackVectorWaitEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerSelectFortifyVectorWaitEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerReinforceCountryWaitEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerAttackCountryWaitEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerClaimCountryWaitEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerDefendCountryWaitEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerAttackCountryWaitEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerFortifyCountryWaitEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerOccupyCountryWaitEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerReinforceCountryWaitEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerSelectAttackVectorWaitEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerSelectFortifyVectorWaitEvent;
 import com.forerunnergames.peril.common.net.events.server.request.PlayerClaimCountryRequestEvent;
 import com.forerunnergames.peril.common.net.events.server.request.PlayerDefendCountryRequestEvent;
 import com.forerunnergames.peril.common.net.events.server.request.PlayerOccupyCountryRequestEvent;
 import com.forerunnergames.peril.common.net.events.server.success.ChatMessageSuccessEvent;
-import com.forerunnergames.peril.common.net.events.server.success.PlayerEndTurnSuccessEvent;
+import com.forerunnergames.peril.common.net.events.server.success.PlayerAttackCountrySuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerCancelFortifySuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerClaimCountryResponseSuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerDefendCountryResponseSuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerEndAttackPhaseSuccessEvent;
+import com.forerunnergames.peril.common.net.events.server.success.PlayerEndTurnSuccessEvent;
+import com.forerunnergames.peril.common.net.events.server.success.PlayerFortifyCountrySuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerJoinGameSuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerOccupyCountryResponseSuccessEvent;
-import com.forerunnergames.peril.common.net.events.server.success.PlayerAttackCountrySuccessEvent;
-import com.forerunnergames.peril.common.net.events.server.success.PlayerFortifyCountrySuccessEvent;
-import com.forerunnergames.peril.common.net.events.server.success.PlayerRetreatSuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerReinforceCountrySuccessEvent;
+import com.forerunnergames.peril.common.net.events.server.success.PlayerRetreatSuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerSelectAttackVectorSuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerTradeInCardsResponseSuccessEvent;
 import com.forerunnergames.peril.common.net.packets.territory.CountryPacket;
@@ -679,7 +679,7 @@ public final class GameLogicProcessor extends AbstractAiProcessor
   }
 
   @Handler
-  void onEvent (final SuspendGameEvent event)
+  void onEvent (final GameSuspendedEvent event)
   {
     Arguments.checkIsNotNull (event, "event");
 
@@ -687,7 +687,7 @@ public final class GameLogicProcessor extends AbstractAiProcessor
   }
 
   @Handler
-  void onEvent (final ResumeGameEvent event)
+  void onEvent (final GameResumedEvent event)
   {
     Arguments.checkIsNotNull (event, "event");
 

--- a/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/ClassicModePlayScreen.java
+++ b/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/ClassicModePlayScreen.java
@@ -115,12 +115,12 @@ import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndFo
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndGameEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndPlayerTurnEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndReinforcementPhaseEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.GameResumedEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.GameSuspendedEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.PlayerDisconnectEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.PlayerLoseGameEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.PlayerWinGameEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.ResumeGameEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.SkipFortifyPhaseEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.SuspendGameEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.direct.PlayerRestoreGameStateEvent;
 import com.forerunnergames.peril.common.net.events.server.request.PlayerOccupyCountryRequestEvent;
 import com.forerunnergames.peril.common.net.events.server.success.ChatMessageSuccessEvent;
@@ -1174,7 +1174,7 @@ public final class ClassicModePlayScreen extends AbstractScreen
   }
 
   @Handler
-  void onEvent (final SuspendGameEvent event)
+  void onEvent (final GameSuspendedEvent event)
   {
     Arguments.checkIsNotNull (event, "event");
 
@@ -1207,7 +1207,7 @@ public final class ClassicModePlayScreen extends AbstractScreen
   }
 
   @Handler
-  void onEvent (final ResumeGameEvent event)
+  void onEvent (final GameResumedEvent event)
   {
     Arguments.checkIsNotNull (event, "event");
 

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/GameResumedEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/GameResumedEvent.java
@@ -1,0 +1,12 @@
+package com.forerunnergames.peril.common.net.events.server.notify.broadcast;
+
+import com.forerunnergames.peril.common.game.GamePhase;
+import com.forerunnergames.peril.common.net.events.server.defaults.AbstractGamePhaseNotificationEvent;
+
+public final class GameResumedEvent extends AbstractGamePhaseNotificationEvent
+{
+  public GameResumedEvent (final GamePhase gamePhase)
+  {
+    super (gamePhase);
+  }
+}

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/GameSuspendedEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/GameSuspendedEvent.java
@@ -1,0 +1,41 @@
+package com.forerunnergames.peril.common.net.events.server.notify.broadcast;
+
+import com.forerunnergames.peril.common.game.GamePhase;
+import com.forerunnergames.peril.common.net.events.server.defaults.AbstractGamePhaseNotificationEvent;
+import com.forerunnergames.tools.common.Strings;
+import com.forerunnergames.tools.net.annotations.RequiredForNetworkSerialization;
+
+public final class GameSuspendedEvent extends AbstractGamePhaseNotificationEvent
+{
+  public enum Reason
+  {
+    PLAYER_UNAVAILABLE,
+    REQUESTED_BY_HOST
+  }
+
+  private final Reason reason;
+
+  public GameSuspendedEvent (final Reason reason)
+  {
+    super (GamePhase.SUSPENDED);
+
+    this.reason = reason;
+  }
+
+  public Reason getReason ()
+  {
+    return reason;
+  }
+
+  @Override
+  public String toString ()
+  {
+    return Strings.format ("{} | Reason: {}", super.toString (), reason);
+  }
+
+  @RequiredForNetworkSerialization
+  private GameSuspendedEvent ()
+  {
+    reason = null;
+  }
+}

--- a/core/src/main/java/com/forerunnergames/peril/core/model/game/GameModel.java
+++ b/core/src/main/java/com/forerunnergames/peril/core/model/game/GameModel.java
@@ -25,6 +25,8 @@ import com.forerunnergames.peril.common.net.events.client.request.inform.PlayerE
 import com.forerunnergames.peril.common.net.events.server.denied.PlayerEndTurnDeniedEvent;
 import com.forerunnergames.peril.common.net.events.server.denied.PlayerJoinGameDeniedEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginGameEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.GameResumedEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.GameSuspendedEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.SkipPlayerTurnEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.WaitingForPlayersToJoinGameEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.direct.PlayerRestoreGameStateEvent;
@@ -44,6 +46,8 @@ import com.forerunnergames.peril.core.model.state.annotations.StateEntryAction;
 import com.forerunnergames.peril.core.model.state.annotations.StateExitAction;
 import com.forerunnergames.peril.core.model.state.annotations.StateTransitionAction;
 import com.forerunnergames.peril.core.model.state.annotations.StateTransitionCondition;
+import com.forerunnergames.peril.core.model.state.events.ResumeGameEvent;
+import com.forerunnergames.peril.core.model.state.events.SuspendGameEvent;
 import com.forerunnergames.tools.common.Arguments;
 import com.forerunnergames.tools.common.id.Id;
 
@@ -103,21 +107,23 @@ public final class GameModel extends AbstractGamePhaseHandler
     publish (new WaitingForPlayersToJoinGameEvent ());
   }
 
-  @StateEntryAction
-  public void suspendGame ()
+  @StateTransitionAction
+  public void suspendGame (final SuspendGameEvent event)
   {
     log.info ("Suspending game...");
 
     resumeGamePhase = getCurrentGamePhase ();
     changeGamePhaseTo (GamePhase.SUSPENDED);
+    publish (new GameSuspendedEvent (event.getReason ()));
   }
 
   @StateTransitionAction
-  public void resumeGame ()
+  public void resumeGame (final ResumeGameEvent event)
   {
     log.info ("Resuming game...");
 
     changeGamePhaseTo (resumeGamePhase);
+    publish (new GameResumedEvent (resumeGamePhase));
   }
 
   @StateTransitionCondition

--- a/core/src/main/java/com/forerunnergames/peril/core/model/game/phase/AbstractGamePhaseHandler.java
+++ b/core/src/main/java/com/forerunnergames/peril/core/model/game/phase/AbstractGamePhaseHandler.java
@@ -17,8 +17,6 @@ import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndPl
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndRoundEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.PlayerLoseGameEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.PlayerWinGameEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.ResumeGameEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.SuspendGameEvent;
 import com.forerunnergames.peril.common.net.packets.card.CardPacket;
 import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
 import com.forerunnergames.peril.common.net.packets.territory.CountryPacket;
@@ -40,6 +38,8 @@ import com.forerunnergames.peril.core.model.playmap.country.CountryOwnerModel;
 import com.forerunnergames.peril.core.model.state.annotations.StateEntryAction;
 import com.forerunnergames.peril.core.model.state.annotations.StateExitAction;
 import com.forerunnergames.peril.core.model.state.events.GamePhaseChangedEvent;
+import com.forerunnergames.peril.core.model.state.events.ResumeGameEvent;
+import com.forerunnergames.peril.core.model.state.events.SuspendGameEvent;
 import com.forerunnergames.peril.core.model.turn.PlayerTurnModel;
 import com.forerunnergames.tools.common.Arguments;
 import com.forerunnergames.tools.common.Event;

--- a/core/src/main/java/com/forerunnergames/peril/core/model/state/StateMachineEventHandler.java
+++ b/core/src/main/java/com/forerunnergames/peril/core/model/state/StateMachineEventHandler.java
@@ -36,15 +36,13 @@ import com.forerunnergames.peril.common.net.events.server.denied.PlayerJoinGameD
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.DeterminePlayerTurnOrderCompleteEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.DistributeInitialArmiesCompleteEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndGameEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndInitialCountryAssignmentPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndInitialReinforcementPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndPlayerTurnEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndReinforcementPhaseEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndInitialCountryAssignmentPhaseEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.ResumeGameEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.SkipFortifyPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.SkipPlayerTurnEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.SkipReinforcementPhaseEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.SuspendGameEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerClaimCountryResponseSuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerJoinGameSuccessEvent;
 import com.forerunnergames.peril.core.model.game.GameModel;
@@ -56,6 +54,8 @@ import com.forerunnergames.peril.core.model.state.events.BeginManualCountryAssig
 import com.forerunnergames.peril.core.model.state.events.CreateGameEvent;
 import com.forerunnergames.peril.core.model.state.events.DestroyGameEvent;
 import com.forerunnergames.peril.core.model.state.events.RandomlyAssignPlayerCountriesEvent;
+import com.forerunnergames.peril.core.model.state.events.ResumeGameEvent;
+import com.forerunnergames.peril.core.model.state.events.SuspendGameEvent;
 import com.forerunnergames.tools.common.Arguments;
 
 import com.google.common.base.Optional;

--- a/core/src/main/java/com/forerunnergames/peril/core/model/state/events/ResumeGameEvent.java
+++ b/core/src/main/java/com/forerunnergames/peril/core/model/state/events/ResumeGameEvent.java
@@ -15,19 +15,15 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.forerunnergames.peril.common.net.events.server.notify.broadcast;
+package com.forerunnergames.peril.core.model.state.events;
 
-import com.forerunnergames.peril.common.game.GamePhase;
-import com.forerunnergames.peril.common.net.events.server.defaults.AbstractGamePhaseNotificationEvent;
-import com.forerunnergames.peril.common.net.events.server.interfaces.EndGamePhaseNotificationEvent;
 import com.forerunnergames.tools.net.annotations.RequiredForNetworkSerialization;
 
-public final class ResumeGameEvent extends AbstractGamePhaseNotificationEvent implements EndGamePhaseNotificationEvent
+public final class ResumeGameEvent implements StateEvent
 {
   @RequiredForNetworkSerialization
   public ResumeGameEvent ()
   {
-    super (GamePhase.SUSPENDED);
   }
 
   @Override

--- a/core/src/main/java/com/forerunnergames/peril/core/model/state/events/SuspendGameEvent.java
+++ b/core/src/main/java/com/forerunnergames/peril/core/model/state/events/SuspendGameEvent.java
@@ -15,25 +15,16 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.forerunnergames.peril.common.net.events.server.notify.broadcast;
+package com.forerunnergames.peril.core.model.state.events;
 
-import com.forerunnergames.peril.common.game.GamePhase;
-import com.forerunnergames.peril.common.net.events.server.defaults.AbstractGamePhaseNotificationEvent;
-import com.forerunnergames.peril.common.net.events.server.interfaces.BeginGamePhaseNotificationEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.GameSuspendedEvent.Reason;
 import com.forerunnergames.tools.common.Strings;
 import com.forerunnergames.tools.net.annotations.RequiredForNetworkSerialization;
 
-public final class SuspendGameEvent extends AbstractGamePhaseNotificationEvent
-        implements BeginGamePhaseNotificationEvent
+public final class SuspendGameEvent implements StateEvent
 {
   private final Reason reason;
   private final long timeoutMillis;
-
-  public enum Reason
-  {
-    PLAYER_UNAVAILABLE,
-    REQUESTED_BY_HOST
-  }
 
   public SuspendGameEvent (final Reason reason)
   {
@@ -42,8 +33,6 @@ public final class SuspendGameEvent extends AbstractGamePhaseNotificationEvent
 
   public SuspendGameEvent (final Reason reason, final long timeoutMillis)
   {
-    super (GamePhase.SUSPENDED);
-
     this.reason = reason;
     this.timeoutMillis = timeoutMillis;
   }
@@ -66,7 +55,7 @@ public final class SuspendGameEvent extends AbstractGamePhaseNotificationEvent
   @Override
   public String toString ()
   {
-    return Strings.format ("{} | Reason: [{}] | TimeoutMillis: [{}]", super.toString (), reason,
+    return Strings.format ("{}: Reason: [{}] | TimeoutMillis: [{}]", getClass ().getSimpleName (), reason,
                            hasTimeout () ? timeoutMillis : "None");
   }
 

--- a/core/src/main/res/GameStateMachine.fsmjava
+++ b/core/src/main/res/GameStateMachine.fsmjava
@@ -171,11 +171,11 @@
                 type="com.forerunnergames.peril.common.net.events.server.notify.broadcast.SkipFortifyPhaseEvent"/>
       </event>
       <event id="onSuspendGameEvent">
-        <parameter type="com.forerunnergames.peril.common.net.events.server.notify.broadcast.SuspendGameEvent"
+        <parameter type="com.forerunnergames.peril.core.model.state.events.SuspendGameEvent"
                    name="event"/>
       </event>
       <event id="onResumeGameEvent">
-        <parameter type="com.forerunnergames.peril.common.net.events.server.notify.broadcast.ResumeGameEvent"
+        <parameter type="com.forerunnergames.peril.core.model.state.events.ResumeGameEvent"
                    name="event"/>
       </event>
       <event id="onEndGameEvent">
@@ -250,7 +250,7 @@
             <onExit action="gameModel.end()"/>
             <!-- Ending the game can occur at any time during the game -->
             <transition event="onEndGameEvent" nextState="EndGame"/>
-            <transition event="onSuspendGameEvent" nextState="Suspended"/>
+            <transition event="onSuspendGameEvent" action="gameModel.suspendGame(event)" nextState="Suspended"/>
             <!-- Initial Game Phase -->
             <state name="InitialPhase">
               <onEntry action="initialPhase.begin()"/>
@@ -442,13 +442,11 @@
               </state>
             </state> <!-- End TurnPhase state -->
             <!-- Resume history state -->
-            <state name="ResumeGame" kind="history">
-              <onEntry action="gameModel.resumeGame()"/>
-            </state> <!-- End ResumeGame state -->
+            <state name="ResumeGame" kind="history"/>
           </state> <!-- End PlayingGame state -->
           <state name="Suspended">
-            <onEntry action="gameModel.suspendGame()"/>
             <transition event="onResumeGameEvent"
+                        action="gameModel.resumeGame(event)"
                         nextState="ResumeGame"/>
           </state> <!-- End Suspended state -->
           <state name="EndGame">

--- a/integration/src/integration/java/com/forerunnergames/peril/integration/core/smoke/GameStateMachineSmokeTest.java
+++ b/integration/src/integration/java/com/forerunnergames/peril/integration/core/smoke/GameStateMachineSmokeTest.java
@@ -25,14 +25,15 @@ import com.forerunnergames.peril.common.eventbus.EventBusFactory;
 import com.forerunnergames.peril.common.game.rules.ClassicGameRules;
 import com.forerunnergames.peril.common.game.rules.GameRules;
 import com.forerunnergames.peril.common.net.events.client.request.HumanPlayerJoinGameRequestEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.ResumeGameEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.SuspendGameEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.GameSuspendedEvent;
 import com.forerunnergames.peril.core.events.DefaultEventRegistry;
 import com.forerunnergames.peril.core.events.EventRegistry;
 import com.forerunnergames.peril.core.model.game.GameModel;
 import com.forerunnergames.peril.core.model.game.GameModelConfiguration;
 import com.forerunnergames.peril.core.model.state.StateMachineEventHandler;
 import com.forerunnergames.peril.core.model.state.events.CreateGameEvent;
+import com.forerunnergames.peril.core.model.state.events.ResumeGameEvent;
+import com.forerunnergames.peril.core.model.state.events.SuspendGameEvent;
 import com.forerunnergames.peril.integration.core.CoreFactory;
 import com.forerunnergames.peril.integration.core.CoreFactory.GameStateMachineConfig;
 import com.forerunnergames.peril.integration.core.StateMachineMonitor;
@@ -152,7 +153,7 @@ public class GameStateMachineSmokeTest
         public void run ()
         {
           initialState.complete (gameStateMachine.getCurrentGameStateName ());
-          eventBus.publish (new SuspendGameEvent (SuspendGameEvent.Reason.REQUESTED_BY_HOST));
+          eventBus.publish (new SuspendGameEvent (GameSuspendedEvent.Reason.REQUESTED_BY_HOST));
         }
       }, eventDelay, TimeUnit.SECONDS);
 

--- a/server/src/main/java/com/forerunnergames/peril/server/controllers/ClientPlayerMapping.java
+++ b/server/src/main/java/com/forerunnergames/peril/server/controllers/ClientPlayerMapping.java
@@ -228,6 +228,21 @@ public final class ClientPlayerMapping
     return playerMaybe.isPresent () && player.equals (playerMaybe.get ());
   }
 
+  public boolean areAllPlayersBounds ()
+  {
+    for (final PlayerPacket player : players)
+    {
+      if (clientsToPlayers.containsValue (player))
+      {
+        continue;
+      }
+
+      return false;
+    }
+
+    return true;
+  }
+
   public Optional <PlayerPacket> playerWith (final String name)
   {
     Arguments.checkIsNotNull (name, "name");


### PR DESCRIPTION
Server:
- Move resume game publication to BEFORE the send game state request
  is sent to Core. This means that, if the game is resumed, it will
  occur prior to the restore state event being sent, so the current
  game phase in the restore state event should be valid.
- Fix resume game event being published even in cases where a player
  is still disconnected.

Core/Common:
- Move SuspendGameEvent/ResumeGameEvent back to core.model.state.events
  package. It was weird that they were published only by server in the
  first place.
- Replace SuspendGameEvent/ResumeGameEvent in common with GameSuspendedEvent
  and GameResumedEvent as broadcast events. The reason enum is in
  GameSuspendedEvent and is shared by SuspendGameEvent internally.
- Core now sends the resumed (current) GamePhase with GameResumedEvent.
  This should resolve the issue brought up in PERIL-896 discussion
  where a player reconnects and the current game phase is still
  SUSPENDED due to another player not being reconnected yet. The
  first reconnected client can reset its proper phase handlers upon
  receipt of the GameResumedEvent (NOTE: this has NOT yet been
  implemented).

PERIL-896 #time 15m #Done #comment See associated commit for fix details.