### PR TITLE
Pin down LibGDX version & its dependencies.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,16 +15,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import groovy.json.JsonSlurper
-
 buildscript {
-  ant.get (src: "http://libgdx.badlogicgames.com/libgdx-site/service/getVersions?release=false", dest: "versions.json", ignoreerrors: "true", verbose: "on")
-  def versionFile = file ("versions.json")
-  def json
-  if (versionFile.exists ()) {
-    json = new JsonSlurper ().parseText (versionFile.text)
-  } else throw new GradleException ("Unable to retrieve latest LibGDX versions, please check your internet connection.")
-
   ext {
     // Gradle
     gradleWrapperVersion = "3.2" // Run './gradlew wrapper' after changing.
@@ -34,14 +25,14 @@ buildscript {
     gradleDependencyManagementPluginVersion = "0.6.1.RELEASE"
 
     // LibGDX
-    libGdxVersion = json.libgdxSnapshot
+    libGdxVersion = "1.9.5"
 
     // RoboVM
-    roboVMVersion = json.robovmVersion
-    roboVMGradleVersion = json.robovmPluginVersion
+    roboVMVersion = "2.3.0"
+    roboVMGradleVersion = "2.3.0"
 
     // Android
-    androidGradleToolsVersion = "2.2.0" //json.androidGradleToolVersion
+    androidGradleToolsVersion = "2.2.0"
     awsAndroidSdkS3Version = "2.3.3"
 
     // Testing
@@ -64,7 +55,7 @@ buildscript {
 
     // Miscellaneous
     fgToolsVersion = "1.1.1-SNAPSHOT"
-    guavaVersion = "v20.0-bugfix" // TODO Use 20.0 release when https://github.com/google/guava/issues/2152 is fixed.
+    guavaVersion = "v20.0-bugfix" // TODO Use latest release when https://github.com/google/guava/issues/2152 is fixed.
     mbassadorVersion = "1.3.0"
     awsJavaSdkBomVersion = "1.11.60"
     jcommanderVersion = "1.58"

--- a/versions.json
+++ b/versions.json
@@ -1,1 +1,0 @@
-{"success":true,"message":"Completed","release":false,"libgdxRelease":"1.9.5","libgdxSnapshot":"1.9.6-SNAPSHOT","robovmVersion":"2.3.0","robovmPluginVersion":"2.3.0","androidBuildtoolsVersion":"23.0.1","androidSDKVersion":"20","androidGradleToolVersion":"1.5.0","gwtVersion":"2.8.0","gwtPluginVersion":"0.6"}


### PR DESCRIPTION
- Stop using LibGDX snapshot versions. Otherwise it will be extremely
  difficult to perform a release. Revert from 1.9.6-SNAPSHOT to 1.9.5.

- Stop querying a list of the latest LibGDX (and LibGDX dependency)
  versions. Remove the json slurping and versions.json file. Many false
  build failures are caused by the versions being downloaded as
  "unknown". Also, this will make builds more reproducible since the
  versions cannot change between a local build and CI build, or between
  two supposedly equivalent CI builds.

- fg-tools is the only snapshot dependency remaining in the project, but
  it is under our control so it is much less of an issue, and can easily
  be frozen to a specific snapshot if necessary (LibGDX could also be
  frozen in theory, but it has so many dependencies, that freezing the
  snapshots correctly for each one would be very time-consuming and
  bug-prone, and there is no simple way to automate it.)