### PR TITLE
Consolidate and fix restore/resume events.

### DIFF
--- a/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/status/StatusMessageGenerator.java
+++ b/client/src/main/java/com/forerunnergames/peril/client/ui/screens/game/play/modes/classic/status/StatusMessageGenerator.java
@@ -43,8 +43,8 @@ import com.forerunnergames.peril.common.net.events.server.interfaces.PlayerArmie
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginAttackPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginFortifyPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginGameEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginInitialReinforcementPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginInitialCountryAssignmentPhaseEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginInitialReinforcementPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginPlayerTurnEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginReinforcementPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.BeginRoundEvent;
@@ -56,6 +56,7 @@ import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndIn
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndPlayerTurnEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndReinforcementPhaseEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.EndRoundEvent;
+import com.forerunnergames.peril.common.net.events.server.notify.broadcast.GameResumedEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.PlayerDisconnectEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.PlayerLoseGameEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.PlayerWinGameEvent;
@@ -68,7 +69,6 @@ import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerReinforceCountryWaitEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerSelectAttackVectorWaitEvent;
 import com.forerunnergames.peril.common.net.events.server.notify.broadcast.wait.PlayerSelectFortifyVectorWaitEvent;
-import com.forerunnergames.peril.common.net.events.server.notify.direct.PlayerRestoreGameStateEvent;
 import com.forerunnergames.peril.common.net.events.server.request.PlayerClaimCountryRequestEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerAttackCountrySuccessEvent;
 import com.forerunnergames.peril.common.net.events.server.success.PlayerCancelFortifySuccessEvent;
@@ -822,7 +822,7 @@ public final class StatusMessageGenerator
   }
 
   @Handler
-  void onEvent (final PlayerRestoreGameStateEvent event)
+  void onEvent (final GameResumedEvent event)
   {
     Arguments.checkIsNotNull (event, "event");
 

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/defaults/AbstractPlayerRestoreGameStateEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/defaults/AbstractPlayerRestoreGameStateEvent.java
@@ -15,13 +15,11 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.forerunnergames.peril.common.net.events.server.notify.direct;
+package com.forerunnergames.peril.common.net.events.server.defaults;
 
 import com.forerunnergames.peril.common.game.GamePhase;
 import com.forerunnergames.peril.common.game.rules.GameRules;
-import com.forerunnergames.peril.common.net.GameServerConfiguration;
-import com.forerunnergames.peril.common.net.events.server.defaults.AbstractPlayerEvent;
-import com.forerunnergames.peril.common.net.events.server.interfaces.DirectPlayerNotificationEvent;
+import com.forerunnergames.peril.common.net.events.server.interfaces.PlayerRestoreGameStateEvent;
 import com.forerunnergames.peril.common.net.packets.card.CardSetPacket;
 import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
 import com.forerunnergames.peril.common.net.packets.territory.CountryPacket;
@@ -35,91 +33,108 @@ import com.google.common.collect.ImmutableSet;
 
 import java.util.Map;
 
-public final class PlayerRestoreGameStateEvent extends AbstractPlayerEvent implements DirectPlayerNotificationEvent
+public abstract class AbstractPlayerRestoreGameStateEvent extends AbstractPlayerEvent
+        implements PlayerRestoreGameStateEvent
 {
   private final PlayerPacket currentPlayer;
   private final GamePhase currentGamePhase;
   private final int currentGameRound;
+  private final GameRules gameRules;
   private final CardSetPacket cardsInHand;
   private final ImmutableSet <CardSetPacket> availableTradeIns;
   private final ImmutableMap <CountryPacket, PlayerPacket> countriesToPlayers;
-  private final GameServerConfiguration gameServerConfig;
 
-  public PlayerRestoreGameStateEvent (final PlayerPacket selfPlayer,
-                                      final PlayerPacket currentPlayer,
-                                      final GamePhase currentGamePhase,
-                                      final int currentGameRound,
-                                      final CardSetPacket cardsInHand,
-                                      final ImmutableSet <CardSetPacket> availableTradeIns,
-                                      final ImmutableMap <CountryPacket, PlayerPacket> countriesToPlayers,
-                                      final GameServerConfiguration gameServerConfig)
+  public AbstractPlayerRestoreGameStateEvent (final PlayerPacket selfPlayer,
+                                              final PlayerPacket currentPlayer,
+                                              final GamePhase currentGamePhase,
+                                              final int currentGameRound,
+                                              final GameRules gameRules,
+                                              final CardSetPacket cardsInHand,
+                                              final ImmutableSet <CardSetPacket> availableTradeIns,
+                                              final ImmutableMap <CountryPacket, PlayerPacket> countriesToPlayers)
   {
     super (selfPlayer);
 
     Arguments.checkIsNotNull (currentPlayer, "currentPlayer");
     Arguments.checkIsNotNull (currentGamePhase, "currentGamePhase");
     Arguments.checkIsNotNegative (currentGameRound, "currentGameRound");
+    Arguments.checkIsNotNull (gameRules, "gameRules");
     Arguments.checkIsNotNull (cardsInHand, "cardsInHand");
     Arguments.checkIsNotNull (availableTradeIns, "availableTradeIns");
     Arguments.checkHasNoNullElements (availableTradeIns, "availableTradeIns");
     Arguments.checkIsNotNull (countriesToPlayers, "countriesToPlayers");
     Arguments.checkHasNoNullKeysOrValues (countriesToPlayers, "countriesToPlayers");
-    Arguments.checkIsNotNull (gameServerConfig, "gameServerConfig");
 
     this.currentPlayer = currentPlayer;
     this.currentGamePhase = currentGamePhase;
     this.currentGameRound = currentGameRound;
+    this.gameRules = gameRules;
     this.cardsInHand = cardsInHand;
     this.availableTradeIns = availableTradeIns;
     this.countriesToPlayers = countriesToPlayers;
-    this.gameServerConfig = gameServerConfig;
   }
 
+  @Override
   public PlayerPacket getSelfPlayer ()
   {
     return getPerson ();
   }
 
+  @Override
   public PlayerPacket getCurrentPlayer ()
   {
     return currentPlayer;
   }
 
+  @Override
   public GamePhase getCurrentGamePhase ()
   {
     return currentGamePhase;
   }
 
+  @Override
   public int getCurrentGameRound ()
   {
     return currentGameRound;
   }
 
+  @Override
+  public GameRules getGameRules ()
+  {
+    return gameRules;
+  }
+
+  @Override
   public CardSetPacket getCardsInHand ()
   {
     return cardsInHand;
   }
 
+  @Override
   public ImmutableSet <CardSetPacket> getAvailableTradeIns ()
   {
     return availableTradeIns;
   }
 
+  @Override
   public ImmutableMap <CountryPacket, PlayerPacket> getCountriesToPlayers ()
   {
     return countriesToPlayers;
   }
 
+  @Override
   public ImmutableSet <Map.Entry <CountryPacket, PlayerPacket>> getCountriesToPlayerEntries ()
   {
     return countriesToPlayers.entrySet ();
   }
 
+  @Override
   public int getSelfOwnedCountryCount ()
   {
     return countriesToPlayers.asMultimap ().inverse ().get (getPerson ()).size ();
   }
 
+  @Override
   public PlayerPacket getOwnerOf (final CountryPacket country)
   {
     Arguments.checkIsNotNull (country, "country");
@@ -134,35 +149,25 @@ public final class PlayerRestoreGameStateEvent extends AbstractPlayerEvent imple
     return owner;
   }
 
-  public GameServerConfiguration getGameServerConfiguration ()
-  {
-    return gameServerConfig;
-  }
-
-  public GameRules getGameRules ()
-  {
-    return gameServerConfig.getGameRules ();
-  }
-
   @Override
   public String toString ()
   {
     return Strings.format (
-                           "{} | CurrentPlayer: [{}] | CurrentPhase: [{}] | CurrentRound: [{}] | CardsInHand: [{}] | "
-                                   + "AvailableTradeIns: [{}] | CountriesToPlayers: [{}] | GameServerConfig: [{}]",
-                           super.toString (), currentPlayer, currentGamePhase, currentGameRound, cardsInHand,
-                           availableTradeIns, countriesToPlayers, gameServerConfig);
+                           "{} | CurrentPlayer: [{}] | CurrentPhase: [{}] | CurrentRound: [{}] | GameRules: [{}] | CardsInHand: [{}] | "
+                                   + "AvailableTradeIns: [{}] | CountriesToPlayers: [{}]",
+                           super.toString (), currentPlayer, currentGamePhase, currentGameRound, gameRules, cardsInHand,
+                           availableTradeIns, countriesToPlayers);
   }
 
   @RequiredForNetworkSerialization
-  private PlayerRestoreGameStateEvent ()
+  protected AbstractPlayerRestoreGameStateEvent ()
   {
     currentPlayer = null;
     currentGamePhase = null;
     currentGameRound = 0;
+    gameRules = null;
     cardsInHand = null;
     availableTradeIns = null;
     countriesToPlayers = null;
-    gameServerConfig = null;
   }
 }

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/interfaces/PlayerRestoreGameStateEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/interfaces/PlayerRestoreGameStateEvent.java
@@ -1,0 +1,37 @@
+package com.forerunnergames.peril.common.net.events.server.interfaces;
+
+import com.forerunnergames.peril.common.game.GamePhase;
+import com.forerunnergames.peril.common.game.rules.GameRules;
+import com.forerunnergames.peril.common.net.packets.card.CardSetPacket;
+import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
+import com.forerunnergames.peril.common.net.packets.territory.CountryPacket;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Map;
+
+public interface PlayerRestoreGameStateEvent extends DirectPlayerNotificationEvent
+{
+  public PlayerPacket getSelfPlayer ();
+
+  public PlayerPacket getCurrentPlayer ();
+
+  public GamePhase getCurrentGamePhase ();
+
+  public int getCurrentGameRound ();
+
+  public GameRules getGameRules ();
+
+  public CardSetPacket getCardsInHand ();
+
+  public ImmutableSet <CardSetPacket> getAvailableTradeIns ();
+
+  public ImmutableMap <CountryPacket, PlayerPacket> getCountriesToPlayers ();
+
+  public ImmutableSet <Map.Entry <CountryPacket, PlayerPacket>> getCountriesToPlayerEntries ();
+
+  public int getSelfOwnedCountryCount ();
+
+  public PlayerPacket getOwnerOf (final CountryPacket country);
+}

--- a/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/GameResumedEvent.java
+++ b/common/src/main/java/com/forerunnergames/peril/common/net/events/server/notify/broadcast/GameResumedEvent.java
@@ -18,12 +18,33 @@
 package com.forerunnergames.peril.common.net.events.server.notify.broadcast;
 
 import com.forerunnergames.peril.common.game.GamePhase;
-import com.forerunnergames.peril.common.net.events.server.defaults.AbstractGamePhaseNotificationEvent;
+import com.forerunnergames.peril.common.game.rules.GameRules;
+import com.forerunnergames.peril.common.net.events.server.defaults.AbstractPlayerRestoreGameStateEvent;
+import com.forerunnergames.peril.common.net.packets.card.CardSetPacket;
+import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
+import com.forerunnergames.peril.common.net.packets.territory.CountryPacket;
+import com.forerunnergames.tools.net.annotations.RequiredForNetworkSerialization;
 
-public final class GameResumedEvent extends AbstractGamePhaseNotificationEvent
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+public final class GameResumedEvent extends AbstractPlayerRestoreGameStateEvent
 {
-  public GameResumedEvent (final GamePhase gamePhase)
+  public GameResumedEvent (final PlayerPacket selfPlayer,
+                           final PlayerPacket currentPlayer,
+                           final GamePhase currentGamePhase,
+                           final int currentGameRound,
+                           final GameRules gameRules,
+                           final CardSetPacket cardsInHand,
+                           final ImmutableSet <CardSetPacket> availableTradeIns,
+                           final ImmutableMap <CountryPacket, PlayerPacket> countriesToPlayers)
   {
-    super (gamePhase);
+    super (selfPlayer, currentPlayer, currentGamePhase, currentGameRound, gameRules, cardsInHand, availableTradeIns,
+           countriesToPlayers);
+  }
+
+  @RequiredForNetworkSerialization
+  private GameResumedEvent ()
+  {
   }
 }

--- a/core/src/main/java/com/forerunnergames/peril/core/model/game/phase/AbstractGamePhaseHandler.java
+++ b/core/src/main/java/com/forerunnergames/peril/core/model/game/phase/AbstractGamePhaseHandler.java
@@ -257,7 +257,8 @@ public abstract class AbstractGamePhaseHandler implements GamePhaseHandler
 
   // ------ Event Handlers ------ //
 
-  @Handler
+  // SuspendGameEvent handler must be handled FIRST to prevent the state machine from invoking end()
+  @Handler (priority = Integer.MAX_VALUE)
   void onEvent (final SuspendGameEvent event)
   {
     Arguments.checkIsNotNull (event, "event");
@@ -267,7 +268,8 @@ public abstract class AbstractGamePhaseHandler implements GamePhaseHandler
     isSuspended = true;
   }
 
-  @Handler
+  // ResumeGameEvent handler must be handled LAST to prevent the state machine from invoking begin()
+  @Handler (priority = Integer.MIN_VALUE)
   void onEvent (final ResumeGameEvent event)
   {
     Arguments.checkIsNotNull (event, "event");

--- a/server/src/main/java/com/forerunnergames/peril/server/communicators/CoreCommunicator.java
+++ b/server/src/main/java/com/forerunnergames/peril/server/communicators/CoreCommunicator.java
@@ -17,13 +17,9 @@
 
 package com.forerunnergames.peril.server.communicators;
 
-import com.forerunnergames.peril.common.net.GameServerConfiguration;
 import com.forerunnergames.peril.common.net.events.server.interfaces.PlayerInputEvent;
-import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
 
 public interface CoreCommunicator
 {
-  void requestSendGameStateTo (final PlayerPacket player, final GameServerConfiguration config);
-
   void notifyInputEventTimedOut (final PlayerInputEvent inputEvent);
 }

--- a/server/src/main/java/com/forerunnergames/peril/server/communicators/DefaultCoreCommunicator.java
+++ b/server/src/main/java/com/forerunnergames/peril/server/communicators/DefaultCoreCommunicator.java
@@ -17,15 +17,10 @@
 
 package com.forerunnergames.peril.server.communicators;
 
-import com.forerunnergames.peril.common.net.GameServerConfiguration;
 import com.forerunnergames.peril.common.net.events.server.interfaces.PlayerInputEvent;
-import com.forerunnergames.peril.common.net.packets.person.PlayerPacket;
 import com.forerunnergames.peril.core.events.internal.interfaces.InternalRequestEvent;
 import com.forerunnergames.peril.core.events.internal.interfaces.InternalResponseEvent;
 import com.forerunnergames.peril.core.events.internal.player.NotifyPlayerInputTimeoutEvent;
-import com.forerunnergames.peril.core.events.internal.player.SendGameStateRequestEvent;
-import com.forerunnergames.peril.core.events.internal.player.SendGameStateResponseEvent;
-import com.forerunnergames.peril.core.events.internal.player.SendGameStateResponseEvent.ResponseCode;
 import com.forerunnergames.tools.common.Arguments;
 import com.forerunnergames.tools.common.Event;
 
@@ -49,21 +44,6 @@ public final class DefaultCoreCommunicator implements CoreCommunicator
     this.eventBus = eventBus;
 
     eventBus.subscribe (this);
-  }
-
-  @Override
-  public void requestSendGameStateTo (final PlayerPacket player, final GameServerConfiguration config)
-  {
-    Arguments.checkIsNotNull (player, "player");
-    Arguments.checkIsNotNull (config, "config");
-
-    final SendGameStateRequestEvent requestEvent = new SendGameStateRequestEvent (player, config);
-    eventBus.publish (requestEvent);
-
-    final Optional <InternalResponseEvent> responseEvent = getResponseFor (requestEvent);
-    if (!responseEvent.isPresent ()) return;
-    final SendGameStateResponseEvent sendGameStateResponse = (SendGameStateResponseEvent) responseEvent.get ();
-    assert sendGameStateResponse.getResponse () == ResponseCode.OK;
   }
 
   @Override


### PR DESCRIPTION
:: Core ::
PlayerRestoreGameStateEvent has now been merged into GameResumedEvent,
and GameResumedEvent inherits from new type PlayerRestoreGameStateEvent.
Currently, it is the only necessary implementation of this type, but the
default/abstract implementation should make future expansions of this
functionality easier.

:: Server ::
Note that server only sends a ResumeGameEvent to Core when all players
are bound after a reconnect. Thus, in order to inform reconnected
clients when the game has not yet been resumed, it will now send a new
GameSuspendedEvent *only to the reconnected client.* This is a bit of a
hack on server's part, but a necessary one.

:: Client ::
Move all phase handler activation logic to resume event handler and
remove all references to PlayerRestoreGameStateEvent. Note that the
client still appears to be broken on reconnect; it does not properly
reset the armies/cards in hand and does not display the correct turn
order.

The fix does work in a live client/server game; i.e. the current phase
reported to the client is accurate.

Additional changes:
- Fix resume causing initial game phase to be "restarted" allowing other
  players to prematurely perform their turns before the reconnected
  player. This was caused by the event handlers in
  core::AbstractGamePhaseHandler not being invoked in the right order
  with the state machine, thus allowing the begin/end lifecycle methods to
  be called erroneously when suspending/resuming the game.

PERIL-896 #time 1h #In Progress - Review